### PR TITLE
Update JetLime to 2.0.1

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -139,7 +139,11 @@ dependencies {
         implementation(material3)
         implementation(material3WindowSizeClass)
     }
-    implementation("io.github.pushpalroy:jetlime:1.0.3")
+    implementation("io.github.pushpalroy:jetlime:2.0.1")
+
+    // TODO: Added this as a temporary fix for a crash in ProgressIndicator, can be removed later.
+    // Issue: https://github.com/JetBrains/compose-multiplatform/issues/4157
+    implementation("androidx.compose.material3:material3-android:1.2.0-beta02")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.1")
     implementation("com.google.maps.android:android-maps-utils:2.3.0")
 

--- a/android-app/src/main/java/dev/johnoreilly/galwaybus/ui/screens/BusRouteScreen.kt
+++ b/android-app/src/main/java/dev/johnoreilly/galwaybus/ui/screens/BusRouteScreen.kt
@@ -2,7 +2,6 @@
 
 package dev.johnoreilly.galwaybus.ui.screens
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.*
@@ -11,12 +10,20 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.pushpal.jetlime.data.JetLimeItemsModel
-import com.pushpal.jetlime.data.config.*
-import com.pushpal.jetlime.ui.JetLimeView
+import androidx.compose.ui.unit.sp
+import com.pushpal.jetlime.EventPointType
+import com.pushpal.jetlime.ItemsList
+import com.pushpal.jetlime.JetLimeColumn
+import com.pushpal.jetlime.JetLimeDefaults
+import com.pushpal.jetlime.JetLimeEvent
+import com.pushpal.jetlime.JetLimeEventDefaults
+import com.surrus.galwaybus.common.model.BusStop
+import dev.johnoreilly.galwaybus.R
 import dev.johnoreilly.galwaybus.ui.viewmodel.GalwayBusViewModel
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
 
 
 @Composable
@@ -44,72 +51,106 @@ fun BusRouteScreen(viewModel: GalwayBusViewModel, busId: String, popBack: () -> 
 }
 
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun RouteTimelineView(viewModel: GalwayBusViewModel, busId: String) {
     val listState = rememberLazyListState()
-    val coroutineScope = rememberCoroutineScope()
 
     val busInfoList by viewModel.busInfoList.collectAsState(emptyList())
     val busStopList by viewModel.allBusStops.collectAsState(emptyList())
+    val busRouteItems = remember { mutableStateListOf<BusRouteItem>() }
 
 //    LaunchedEffect(viewModel) {
 //        viewModel.setRouteId("401")
 //    }
 
-    val jetLimeItemsModel by remember {
+    LaunchedEffect(key1 = busInfoList) {
+        if (busInfoList.isNotEmpty()) {
+            val busInfo = busInfoList.find { it.vehicle_id == busId }
 
-        derivedStateOf {
-            val jetItemList: MutableList<JetLimeItemsModel.JetLimeItem> = mutableStateListOf()
+            val nextStopRef = busInfo?.next_stop_ref
+            println("extStopRef = $nextStopRef")
 
-            if (busInfoList.isNotEmpty()) {
-                val busInfo = busInfoList.find { it.vehicle_id == busId }
+            val busList = busInfo?.route ?: emptyList()
+            var scrollToIndex = 0
+            busRouteItems.clear()
+            busList.forEachIndexed { index, busStopRef ->
+                var hasPassed = false
+                val busStop = busStopList.find { it.stopRef == busStopRef }
 
-                val nextStopRef = busInfo?.next_stop_ref
-                println("extStopRef = $nextStopRef")
+                val busStopIndex = busList.indexOf(busStopRef)
+                val nextBusStopIndex = busList.indexOf(nextStopRef)
 
-                val busList = busInfo?.route ?: emptyList()
-                var scrollToIndex = 0
-                busList.forEachIndexed { index, busStopRef ->
-                    val busStop = busStopList.find { it.stopRef == busStopRef }
+                if (busStopRef == nextStopRef) {
+                    scrollToIndex = index
+                } else {
+                    hasPassed = busStopIndex < nextBusStopIndex
+                }
 
-                    val busStopIndex = busList.indexOf(busStopRef)
-                    val nextBusStopIndex = busList.indexOf(nextStopRef)
-
-                    val jetLimeItemConfig = if (busStopRef == nextStopRef) {
-                        scrollToIndex = index
-                        JetLimeItemConfig(iconAnimation = IconAnimation())
-                    }
-                    else {
-                        if (busStopIndex < nextBusStopIndex) {
-                            JetLimeItemConfig(itemHeight = 80.dp, iconType = IconType.Checked)
-                        } else {
-                            JetLimeItemConfig(itemHeight = 80.dp, iconType = IconType.Empty)
-                        }
-
-                    }
-
-                    jetItemList.add(
-                        JetLimeItemsModel.JetLimeItem(
-                            title = busStop?.shortName ?: "",
-                            description = busStopRef,
-                            jetLimeItemConfig = jetLimeItemConfig
+                busStop?.let { safeBusStop ->
+                    busRouteItems.add(
+                        BusRouteItem(
+                            busStop = safeBusStop,
+                            busStopRef = busStopRef,
+                            shouldShowAnimation = busStopRef == nextStopRef,
+                            hasPassed = hasPassed
                         )
                     )
                 }
-                coroutineScope.launch {
-                    listState.scrollToItem(scrollToIndex)
-                }
             }
 
-            JetLimeItemsModel(list = jetItemList)
+            // Scroll with a delay
+            delay(1000)
+            listState.animateScrollToItem(index = scrollToIndex)
         }
     }
 
-    JetLimeView(
-        jetLimeItemsModel = jetLimeItemsModel,
-        jetLimeViewConfig = JetLimeViewConfig(lineType = LineType.Solid),
-        listState = listState
-    )
-
+    JetLimeColumn(
+        modifier = Modifier.padding(start = 32.dp, top = 16.dp).fillMaxSize(),
+        itemsList = ItemsList(busRouteItems),
+        listState = listState,
+        key = { _, item -> item.busStop.stop_id },
+        style = JetLimeDefaults.columnStyle()
+    ) { _, item, position ->
+        JetLimeEvent(
+            style = JetLimeEventDefaults.eventStyle(
+                position = position,
+                pointAnimation = if (item.shouldShowAnimation) JetLimeEventDefaults.pointAnimation() else null,
+                pointType = if (item.hasPassed) EventPointType.custom(icon = painterResource(id = R.drawable.icon_check)) else EventPointType.filled()
+            )
+        ) {
+            BusStopContent(item)
+        }
+    }
 }
+
+@Composable
+fun BusStopContent(item: BusRouteItem, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(0.9f),
+    ) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold,
+            text = item.busStop.shortName,
+        )
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            fontSize = 14.sp,
+            text = item.busStopRef,
+        )
+    }
+}
+
+data class BusRouteItem(
+    val busStop: BusStop,
+    val busStopRef: String = "",
+    val shouldShowAnimation: Boolean = false,
+    val hasPassed: Boolean = false,
+)

--- a/android-app/src/main/res/drawable/icon_check.xml
+++ b/android-app/src/main/res/drawable/icon_check.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#2A6419"
+      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z" />
+</vector>


### PR DESCRIPTION
Migrate to the new APIs of **JetLime 2.0.1** to show the timeline view in `BusRouteScreen`. 

Also faced a crash with ProgressIndicator after launching the app. Found the issue here: https://github.com/JetBrains/compose-multiplatform/issues/4157. Added "material3-android" dependency as a temporary fix which works fine for now.

Demo for the BusRouteScreen with the new version:

https://github.com/joreilly/GalwayBus/assets/19844292/3991b8fb-2c69-491e-9c9d-a528bed2025a

