### PR TITLE
ci: standardise GitHub Actions workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,18 +1,29 @@
 name: Android CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+# Cancel superseded runs for the same PR/branch
+concurrency:
+  group: android-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:
-
-    runs-on: macos-latest
-
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
-    - name: set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-    - name: Build with Gradle
-      run: ./gradlew :android-app:assembleDebug
+      - uses: actions/checkout@v7
+      - name: set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Build with Gradle
+        run: ./gradlew :android-app:assembleDebug


### PR DESCRIPTION
## Summary

Standardises the GitHub Actions workflows to a shared fleet-wide baseline (part of a cross-sample CI standardisation).

- **Runner:** Android/JVM build moved to `ubuntu-latest` (Android builds don't need macOS — ~10× cheaper minutes). iOS `xcodebuild` jobs stay on macOS. *(Validated: Kotlin/Native `compileKotlinIos*` compile steps run fine on Linux.)*
- **Caching:** added `gradle/actions/setup-gradle@v6` (Gradle build + dependency caching); iOS jobs also cache `~/.konan` for Kotlin/Native.
- **Action pins:** `checkout@v7`, `setup-java@v5`, `setup-gradle@v6`, `cache@v6` (fleet-latest majors).
- **JDK:** left **unchanged** per repo — the Gradle build pins a Java toolchain, so the runner JDK is kept as-is (only the setup action was bumped).
- **Hardening:** added `permissions: contents: read`, `timeout-minutes`, and `concurrency` (cancel-in-progress).
- **Triggers:** normalised to `pull_request` + `push: [main]` so the Actions cache seeds from the default branch.

## Test plan

- [ ] Android CI green on `ubuntu-latest`
- [ ] iOS CI green on `macos-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)