### PR TITLE
Add GitHub Pages deploy workflow for web client

### DIFF
--- a/.github/workflows/build-and-publish-web.yml
+++ b/.github/workflows/build-and-publish-web.yml
@@ -1,0 +1,41 @@
+name: Build and Publish
+
+# configure manual trigger
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Test and Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+
+      # Setup Java environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      # Check out current repository
+      - name: Fetch Sources
+        uses: actions/checkout@v7
+
+      - uses: gradle/actions/setup-gradle@v6
+
+      # Build application
+      - name: Build
+        run: ./gradlew :webApp:wasmJsBrowserDistribution
+
+      # If main branch update, deploy to gh-pages
+      - name: Deploy
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        with:
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: webApp/build/dist/wasmJs/productionExecutable # The folder the action should deploy.
+          CLEAN: true # Automatically remove deleted files from the deploy branch


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-and-publish-web.yml`, a manually-triggered (`workflow_dispatch`) workflow that builds the wasmJs `:webApp` distribution and deploys it to the `gh-pages` branch — matching the deploy setup used in the other sample repos (ClimateTraceKMP, chip-8, StarWars).
- Applies fleet-standard hardening the older samples lack: `permissions: contents: write`, `timeout-minutes`, and `gradle/actions/setup-gradle@v6` caching.
- Leaves the existing build-only `web.yml` untouched.

## Test plan
- [ ] Trigger the workflow from the Actions tab on `main`
- [ ] Confirm it builds `:webApp:wasmJsBrowserDistribution` and pushes to `gh-pages`
- [ ] Set Pages source to the `gh-pages` branch (Settings → Pages) if not already configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)