### PR TITLE
Bump Android versionNum to 100 for internal release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ default_platform :android
 
 platform :android do
 
-    versionNum = 99
+    versionNum = 100
 
     before_all do
     end


### PR DESCRIPTION
## Summary
- Bumps `versionNum` 99 → 100 in `fastlane/Fastfile` (versionCode `1001099` → `1001100`).
- versionCode `1001099` was already used on the Play Store internal track, so version 99 could not be re-uploaded. This bump matches the build now live on the **internal test track** (`1.1.100`).

## Test plan
- [x] `fastlane android deployInternalTest` builds `:androidApp:bundleRelease` and uploads the AAB
- [x] Upload to Play Store internal track succeeded (versionCode `1001100`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)