### PR TITLE
Fix Scan tab crash on release builds (R8 stripping ML Kit)

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -31,6 +31,17 @@
 # Belt-and-braces: keep the app's own serializable model classes intact.
 -keep @kotlinx.serialization.Serializable class dev.johnoreilly.galwaybus.** { *; }
 
+# ── ML Kit text recognition (camera "Scan" tab) ──────────────────────────────
+# TextRecognition.getClient() resolves its internal components reflectively via
+# GMS/Firebase ComponentRegistrar discovery. Under R8 fullMode (default on AGP 8+)
+# those internal classes get stripped/renamed, leaving a null field that crashes
+# with an NPE inside com.google.mlkit.vision.text.internal.zzo. Keep the ML Kit
+# public API and its GMS-internal vision-text implementation packages.
+-keep class com.google.mlkit.** { *; }
+-keep class com.google.android.gms.internal.mlkit_vision_text_common.** { *; }
+-keep class com.google.android.gms.internal.mlkit_vision_text.** { *; }
+-dontwarn com.google.mlkit.**
+
 # ── Ktor / OkHttp optional transitive deps (compile-only, not shipped) ────────
 -dontwarn org.slf4j.**
 -dontwarn okhttp3.**

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ default_platform :android
 
 platform :android do
 
-    versionNum = 100
+    versionNum = 102
 
     before_all do
     end


### PR DESCRIPTION
## Summary
The camera **Scan** tab crashed on release/internal-track builds (fine in debug). The deobfuscated stacktrace pinned it to a `NullPointerException` inside `com.google.mlkit.vision.text.internal.zzo`, reached from `TextRecognition.getClient()` at `StopScanner_android.kt:94`.

**Cause:** R8 fullMode (default on AGP 8+) was stripping ML Kit's reflectively-loaded GMS-internal `mlkit_vision_text` classes (confirmed via retrace + `usage.txt`), leaving a null internal component.

**Fix:** add keep rules for the ML Kit API and its vision-text internal packages in `androidApp/proguard-rules.pro`. Also bumps `versionNum` to 102 for the internal-track redeploy.

## Test plan
- [x] Retraced the obfuscated crash to confirm ML Kit / R8 as the cause
- [x] Built a minified release APK with the keep rules, installed on device, opened Scan → camera preview shows, no crash
- [x] Verified `usage.txt`: only the unused `mlkit_vision_text_bundled_common` variant is stripped; `vision_text_common` (the crashing package) is retained
- [x] Deployed `1.1.102` (versionCode 1001102) to the Play internal test track

🤖 Generated with [Claude Code](https://claude.com/claude-code)