### PR TITLE
Internal release 103: fix wrong vehicle id in stops view

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -100,12 +100,17 @@ platform :android do
         # No version_code: supply promotes whichever single 'completed' release is in the
         # internal track. If internal ever has more than one release, supply errors and asks
         # for :version_code rather than guessing.
+        # This is a promote-only run: no AAB is uploaded, so supply has no version code in
+        # context. skip_upload_changelogs/aab must be set or supply hard-errors trying to attach
+        # changelogs ("no version code given"). We only move the existing release between tracks.
         supply(
             package_name: "dev.johnoreilly.galwaybus",
             track: "internal",
             track_promote_to: "production",
             skip_upload_apk: true,
+            skip_upload_aab: true,
             skip_upload_metadata: true,
+            skip_upload_changelogs: true,
             skip_upload_images: true,
             skip_upload_screenshots: true
         )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ default_platform :android
 
 platform :android do
 
-    versionNum = 102
+    versionNum = 103
 
     before_all do
     end

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
@@ -161,8 +161,6 @@ class GalwayBusRepository(
             StopDeparturesResponse(times = emptyList())
         }
 
-        val s = snapshot()
-        val stopLocation = s.stops[stopId]
         val nowMs = nowEpochMilliseconds()
         val liveTimes = liveResponse.times.filter { it.depart_timestamp != null }.sortedBy { it.depart_timestamp }
         val result = mutableListOf<DepartureTime>()
@@ -200,13 +198,10 @@ class GalwayBusRepository(
                 val staticInstant = Instant.parse(scheduled.depart_timestamp!!)
                 val delay = (liveInstant - staticInstant).inWholeSeconds.toInt()
 
-                // Find vehicle ID if possible
+                // Attach a live vehicle only via a trustworthy link (exact trip, or the bus's own
+                // next-stop prediction for this stop). No headsign guessing — see matchVehicle.
                 val busesOnRoute = livePositions[scheduled.timetable_id] ?: emptyList()
-                val vehicle = busesOnRoute
-                    .find { it.trip_duid == scheduled.tripId && (it.vehicle_id == null || it.vehicle_id !in usedVehicleIds) }
-                    ?: busesOnRoute.find { 
-                        it.vehicle_id != null && it.vehicle_id !in usedVehicleIds && headsignMatches(it.headsign, scheduled.display_name) 
-                    }
+                val vehicle = matchVehicle(busesOnRoute, scheduled.tripId, stopId, usedVehicleIds)
 
                 val vehicleId = vehicle?.vehicle_id ?: live.vehicleId
                 if (!vehicleId.isNullOrBlank()) usedVehicleIds.add(vehicleId)
@@ -218,20 +213,11 @@ class GalwayBusRepository(
                     vehicleId = vehicleId
                 ))
             } else {
-                // Second pass: try to match live-only departure to a vehicle from bus.json
+                // Live-only departure (no schedule match): with no trip id, the only trustworthy
+                // link is a bus whose own next-stop prediction includes this stop.
                 val busesOnRoute = livePositions[live.timetable_id] ?: emptyList()
-                val bestBus = if (stopLocation != null) {
-                    busesOnRoute
-                        .filter { it.vehicle_id !in usedVehicleIds && headsignMatches(it.headsign, live.display_name) }
-                        .minByOrNull { bus: BusLocation ->
-                        val dx = bus.longitude - stopLocation.lon
-                        val dy = bus.latitude - stopLocation.lat
-                        dx * dx + dy * dy
-                    }
-                } else {
-                    busesOnRoute.firstOrNull { it.vehicle_id !in usedVehicleIds && headsignMatches(it.headsign, live.display_name) }
-                }
-                
+                val bestBus = matchVehicle(busesOnRoute, tripId = null, stopId = stopId, usedVehicleIds = usedVehicleIds)
+
                 val finalVehicleId = bestBus?.vehicle_id ?: live.vehicleId
                 if (!finalVehicleId.isNullOrBlank()) usedVehicleIds.add(finalVehicleId)
 
@@ -247,7 +233,7 @@ class GalwayBusRepository(
                 val staticInstant = Instant.parse(scheduled.depart_timestamp!!)
                 if (staticInstant.toEpochMilliseconds() >= nowMs) {
                     val busesOnRoute = livePositions[scheduled.timetable_id] ?: emptyList()
-                    val vehicle = busesOnRoute.find { it.trip_duid == scheduled.tripId && (it.vehicle_id == null || it.vehicle_id !in usedVehicleIds) }
+                    val vehicle = matchVehicle(busesOnRoute, scheduled.tripId, stopId, usedVehicleIds)
                     val vehicleId = vehicle?.vehicle_id
                     if (!vehicleId.isNullOrBlank()) usedVehicleIds.add(vehicleId)
                     
@@ -260,28 +246,32 @@ class GalwayBusRepository(
         return result.sortedBy { it.depart_timestamp } to livePositions
     }
 
-    private fun normalizeHeadsignForMatch(headsign: String?): String {
-        if (headsign.isNullOrBlank()) return ""
+    /**
+     * Picks the live vehicle serving a departure, using only trustworthy links:
+     *  1. exact trip match (the bus is running the departure's trip), or
+     *  2. the bus's own next-stop prediction includes this stop.
+     *
+     * We deliberately do NOT guess by route+headsign: frequent routes (e.g. 401) run several
+     * buses in the same direction at once, so a headsign match attaches an arbitrary bus to the
+     * "next due" departure and shows the wrong vehicle id. No id is better than a wrong id.
+     */
+    private fun matchVehicle(
+        busesOnRoute: List<BusLocation>,
+        tripId: String?,
+        stopId: String,
+        usedVehicleIds: Set<String>
+    ): BusLocation? {
+        fun available(bus: BusLocation): Boolean {
+            val vid = bus.vehicle_id
+            return !vid.isNullOrBlank() && vid !in usedVehicleIds
+        }
 
-        var normalized = headsign
-            .trim()
-            .replace(Regex("\\s+"), " ")
-            .lowercase()
-
-        normalized = normalized.removePrefix("towards ")
-            .removePrefix("to ")
-
-        // Strip common suffixes like "X (via ...)".
-        normalized = normalized.substringBefore(" (")
-        normalized = normalized.substringBefore(" via ")
-
-        return normalized.trim()
-    }
-
-    private fun headsignMatches(busHeadsign: String?, departureHeadsign: String?): Boolean {
-        val a = normalizeHeadsignForMatch(busHeadsign)
-        val b = normalizeHeadsignForMatch(departureHeadsign)
-        return a.isNotEmpty() && a == b
+        if (tripId != null) {
+            busesOnRoute.firstOrNull { it.trip_duid == tripId && available(it) }?.let { return it }
+        }
+        return busesOnRoute.firstOrNull { bus ->
+            available(bus) && bus.next_stops?.any { it.stop_ref == stopId } == true
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fix the stops view attributing the **wrong vehicle id** to departures on frequent routes (e.g. 401). The old fallback matched a live bus by route + headsign and picked the first in feed order — arbitrary, not the bus actually approaching the stop. Now a vehicle is attached only via an exact trip match or the bus's own next-stop prediction; the headsign guess is removed (no id beats a wrong id).
- Bump Android `versionNum` to **103** for the internal test release.

## Test plan
- [x] `:shared:compileAndroidMain`, `:shared:compileKotlinJvm`, `:shared:jvmTest` pass
- [x] Root cause validated against the live feed (stop 522111 / Salthill Prom, route 401)
- [ ] Verify vehicle ids render correctly in the internal-test build on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)