### PR TITLE
Rework Track Bus route timeline (internal release 107)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ default_platform :android
 
 platform :android do
 
-    versionNum = 105
+    versionNum = 106
 
     before_all do
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ default_platform :android
 
 platform :android do
 
-    versionNum = 106
+    versionNum = 107
 
     before_all do
     end

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
@@ -165,29 +165,28 @@ private enum class Screen {
     MAIN, TRACKING
 }
 
-/** Formats departure countdown with live delays. Returns "Due", "3 min", "8 min (late)", etc. */
-fun DepartureTime.formatWithLive(nowMs: Long): String {
-    val delaySeconds = delaySeconds
+/** Bare countdown to the (live-adjusted) departure. Returns "Due", "3 min", "1h 5min", "N/A". */
+fun DepartureTime.formatCountdown(nowMs: Long): String {
     val scheduledMinutes = depart_timestamp?.let { ts ->
-        Instant.parse(ts).let { instant ->
-            ((instant.toEpochMilliseconds() - nowMs) / 1000 / 60).toInt()
-        }
+        ((Instant.parse(ts).toEpochMilliseconds() - nowMs) / 1000 / 60).toInt()
     } ?: return "N/A"
-
     return when {
-        delaySeconds != null -> {
-            val liveDisplay = when {
-                scheduledMinutes <= 0 -> "Due"
-                scheduledMinutes < 60 -> "$scheduledMinutes min"
-                else -> "${scheduledMinutes / 60}h ${scheduledMinutes % 60}min"
-            }
-            val lateLabel = if (delaySeconds > 30) " (late)" else if (delaySeconds < -30) " (early)" else ""
-            "$liveDisplay$lateLabel"
-        }
         scheduledMinutes <= 0 -> "Due"
         scheduledMinutes < 60 -> "$scheduledMinutes min"
         else -> "${scheduledMinutes / 60}h ${scheduledMinutes % 60}min"
     }
+}
+
+/**
+ * Countdown with a "(late)"/"(early)" suffix baked in, for the departures list where there's no
+ * separate delay status shown. Where the delay is displayed on its own (e.g. the tracking card),
+ * use [formatCountdown] instead so the lateness isn't stated twice.
+ */
+fun DepartureTime.formatWithLive(nowMs: Long): String {
+    val countdown = formatCountdown(nowMs)
+    val delaySeconds = delaySeconds ?: return countdown
+    val lateLabel = if (delaySeconds > 30) " (late)" else if (delaySeconds < -30) " (early)" else ""
+    return "$countdown$lateLabel"
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
@@ -1061,7 +1060,9 @@ private fun TrackingInfoCard(
                 )
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        text = departure.formatWithLive(nowMs),
+                        // Plain countdown — the delay is shown separately as statusText below,
+                        // so we avoid the ambiguous "15 min (late)" that reads as "15 min late".
+                        text = departure.formatCountdown(nowMs),
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.onSurface
                     )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
@@ -48,8 +48,8 @@ import com.pushpal.jetlime.EventPointType
 import com.pushpal.jetlime.ItemsList
 import com.pushpal.jetlime.JetLimeColumn
 import com.pushpal.jetlime.JetLimeDefaults
-import com.pushpal.jetlime.JetLimeEvent
 import com.pushpal.jetlime.JetLimeEventDefaults
+import com.pushpal.jetlime.JetLimeExtendedEvent
 import dev.johnoreilly.galwaybus.location.NearbyStop
 import dev.johnoreilly.galwaybus.location.UserLocation
 import dev.johnoreilly.galwaybus.map.BusMapView
@@ -891,7 +891,7 @@ private fun BusTrackingView(
                     mapArea(Modifier.fillMaxHeight().weight(1f))
                     if (timelineStops.isNotEmpty()) {
                         Box(Modifier.fillMaxHeight().width(1.dp).background(MaterialTheme.colorScheme.outlineVariant))
-                        timeline(Modifier.fillMaxHeight().width(220.dp))
+                        timeline(Modifier.fillMaxHeight().width(300.dp))
                     }
                 }
             }
@@ -904,6 +904,7 @@ private fun BusTrackingView(
  * passed are checked, the stop it's currently nearest gets an animated node, and the
  * user's target stop is highlighted.
  */
+@OptIn(ExperimentalComposeApi::class)
 @Composable
 private fun RouteTimeline(
     stops: List<Stop>,
@@ -949,7 +950,7 @@ private fun RouteTimeline(
     JetLimeColumn(
         itemsList = ItemsList(stops),
         listState = listState,
-        modifier = modifier.padding(start = 20.dp, top = 12.dp, end = 12.dp),
+        modifier = modifier.padding(start = 4.dp, top = 12.dp, end = 12.dp),
         key = { _, stop -> stop.stop_ref },
         style = JetLimeDefaults.columnStyle(lineBrush = JetLimeDefaults.lineSolidBrush(primary))
     ) { index, stop, position ->
@@ -957,7 +958,18 @@ private fun RouteTimeline(
         val isCurrent = busIndex >= 0 && index == busIndex
         val isTarget = stop.stop_ref == targetStopRef
 
-        JetLimeEvent(
+        // Predicted arrival for this stop ("Due" / "3 min" / "1h 9min"), if the live
+        // next_stops payload covers it. Shown in the left gutter for stops still ahead.
+        val etaText = etaByStopRef[stop.stop_ref]?.let { ts ->
+            val mins = ((Instant.parse(ts).toEpochMilliseconds() - nowMs) / 1000 / 60).toInt()
+            when {
+                mins <= 0 -> "Due"
+                mins < 60 -> "$mins′"
+                else -> "${mins / 60}h ${mins % 60}′"
+            }
+        }
+
+        JetLimeExtendedEvent(
             style = JetLimeEventDefaults.eventStyle(
                 position = position,
                 pointType = when {
@@ -975,7 +987,27 @@ private fun RouteTimeline(
                 pointColor = if (isTarget || isCurrent) primary else onSurfaceVariant,
                 pointStrokeColor = if (isTarget || isCurrent) primary else onSurfaceVariant,
                 pointAnimation = if (isCurrent) JetLimeEventDefaults.pointAnimation() else null
-            )
+            ),
+            additionalContentMaxWidth = 52.dp,
+            additionalContent = {
+                // Minutes-to-arrival, right-aligned against the line. Only for stops the
+                // bus hasn't reached yet; passed stops leave the gutter blank. The box is
+                // always the full width so every node lines up regardless of gutter text.
+                Box(
+                    Modifier.width(52.dp).padding(end = 8.dp),
+                    contentAlignment = Alignment.CenterEnd
+                ) {
+                    if (!hasPassed && etaText != null) {
+                        Text(
+                            etaText,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (isTarget || isCurrent) primary else onSurfaceVariant,
+                            fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
+                            maxLines = 1
+                        )
+                    }
+                }
+            }
         ) {
             Column(Modifier.padding(bottom = 4.dp)) {
                 Text(
@@ -986,25 +1018,24 @@ private fun RouteTimeline(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-                val etaText = etaByStopRef[stop.stop_ref]?.let { ts ->
-                    val mins = ((Instant.parse(ts).toEpochMilliseconds() - nowMs) / 1000 / 60).toInt()
-                    when {
-                        mins <= 0 -> "Due"
-                        mins < 60 -> "$mins min"
-                        else -> "${mins / 60}h ${mins % 60}min"
-                    }
+                // "Next stop"/"Your stop" get an emphasised label with the stop id beneath;
+                // every other stop just shows its id.
+                val label = when {
+                    isTarget -> "Your stop"
+                    isCurrent -> "Next stop"
+                    else -> null
                 }
-                val subtitle = when {
-                    isTarget -> etaText?.let { "Your stop · $it" } ?: "Your stop"
-                    isCurrent -> etaText?.let { "Next stop · $it" } ?: "Next stop"
-                    hasPassed -> stop.stop_id
-                    etaText != null -> etaText
-                    else -> stop.stop_id
+                label?.let {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = primary
+                    )
                 }
                 Text(
-                    subtitle,
+                    stop.stop_id,
                     style = MaterialTheme.typography.labelSmall,
-                    color = if (isTarget || isCurrent) primary else onSurfaceVariant
+                    color = onSurfaceVariant
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
@@ -209,12 +209,20 @@ class GalwayBusRepository(
 
     /**
      * Picks the live vehicle serving a departure, using only trustworthy links:
-     *  1. exact trip match (the bus is running the departure's trip), or
+     *  1. exact trip match (the bus is running the departure's trip) AND the stop is still ahead of
+     *     the bus, or
      *  2. the bus's own next-stop prediction includes this stop.
      *
      * We deliberately do NOT guess by route+headsign: frequent routes (e.g. 401) run several
      * buses in the same direction at once, so a headsign match attaches an arbitrary bus to the
      * "next due" departure and shows the wrong vehicle id. No id is better than a wrong id.
+     *
+     * The trip match alone is not enough: a departure can linger on a future scheduled slot after
+     * the vehicle has already driven past the stop (the trip's real-time updates drop out, so the
+     * backend reverts to the stale static time). Attaching the bus then shows a vehicle that's
+     * visibly well beyond the stop. When we have the bus's next_stops we require the stop to be in
+     * that ahead-list; only when it's absent (no position/sequence data at all) do we fall back to
+     * trusting the trip match, since we then can't tell whether it has passed.
      */
     private fun matchVehicle(
         busesOnRoute: List<BusLocation>,
@@ -226,9 +234,15 @@ class GalwayBusRepository(
             val vid = bus.vehicle_id
             return !vid.isNullOrBlank() && vid !in usedVehicleIds
         }
+        // True when the stop is still ahead of the bus, or we have no ahead-list to judge by.
+        fun stopAhead(bus: BusLocation): Boolean {
+            val ahead = bus.next_stops ?: return true
+            return ahead.any { it.stop_ref == stopId }
+        }
 
         if (tripId != null) {
-            busesOnRoute.firstOrNull { it.trip_duid == tripId && available(it) }?.let { return it }
+            busesOnRoute.firstOrNull { it.trip_duid == tripId && available(it) && stopAhead(it) }
+                ?.let { return it }
         }
         return busesOnRoute.firstOrNull { bus ->
             available(bus) && bus.next_stops?.any { it.stop_ref == stopId } == true


### PR DESCRIPTION
## Summary
Reworks the Track Bus route timeline so it reads like a departures board:

- Per-stop ETAs move into a **left gutter** (via `JetLimeExtendedEvent`), shown only for stops the bus hasn't reached yet; passed stops leave it blank. Minutes use `′` (e.g. `4′`, `1h 9′`).
- The gutter is a **fixed width** so every node circle lines up regardless of whether it has a time.
- The current stop is labelled **"Next stop"** and the target **"Your stop"**, each rendered the same way — emphasised label with the **stop id** beneath.
- Tightened the timeline's left padding so the gutter hugs the edge (was a large empty margin on narrow/phone layouts).
- Widened the side-panel timeline (220 → 300dp) to make room for the gutter.
- Bumped version to **1.1.107** (versionCode 1001107); published to the Play **internal** track.

This PR also carries three earlier local-only release commits (105 → 107) that hadn't been pushed to `main` yet.

## Test plan
- [x] `:desktopApp:run` — compiles and launches
- [x] Verified live on desktop: gutter ETAs, aligned nodes, `Next stop`/`Your stop` labels with stop id underneath, reduced left padding
- [x] Built signed release AAB and uploaded to Play internal test (`fastlane deployInternalTest`) as 1.1.107
- [ ] On-device sanity check once the internal track propagates

🤖 Generated with [Claude Code](https://claude.com/claude-code)