### PR TITLE
Fix CI archive signing for iOS TestFlight publish

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -173,6 +173,8 @@ end
 
 
 platform :ios do
+    require "base64"
+    require "tempfile"
 
     ios_app_identifier = "dev.johnoreilly.galwaybus"
     ios_app_name = "Galway Bus"
@@ -181,7 +183,8 @@ platform :ios do
     # Resolves an App Store Connect API key from environment variables so no Apple ID
     # password or 2FA is ever needed (works identically locally and in CI). Create the
     # key once at App Store Connect > Users and Access > Integrations > App Store Connect
-    # API (needs App Manager or Admin role to also create the app record), then set:
+    # API (needs Admin role — App Manager can't drive Xcode's Cloud Managed Signing during
+    # `beta`'s archive/export step, and can't create the app record either), then set:
     #   ASC_KEY_ID      - the key's Key ID
     #   ASC_ISSUER_ID   - the Issuer ID shown above the keys table
     #   ASC_KEY_CONTENT - base64 of the downloaded AuthKey_XXXX.p8
@@ -245,14 +248,32 @@ platform :ios do
         # no agvtool/apple-generic versioning setup is required on the target.
         build_number = ENV["BUILD_NUMBER"] || Time.now.utc.strftime("%Y%m%d%H%M")
 
+        # app_store_connect_api_key above only authenticates fastlane's own API calls (e.g.
+        # upload_to_testflight below) — it does NOT feed into xcodebuild's own automatic
+        # signing. On a machine with no Apple ID signed into Xcode (any CI runner),
+        # -allowProvisioningUpdates alone fails archiving with "No Accounts" / "No profiles
+        # ... found". Writing the key to a temp .p8 and passing it via xcodebuild's own
+        # -authenticationKey* flags lets automatic signing use the API key directly. The key
+        # also needs Admin (not App Manager) role for Xcode's Cloud Managed Signing to be
+        # allowed to create/download a Distribution certificate — App Manager alone hits
+        # "Cloud signing permission error" / "No signing certificate found" on export.
+        auth_key_file = Tempfile.new(["AuthKey_#{ENV.fetch('ASC_KEY_ID')}", ".p8"])
+        auth_key_file.write(Base64.decode64(ENV.fetch("ASC_KEY_CONTENT")))
+        auth_key_file.close
+
         build_app(
             project: "iosApp/iosApp.xcodeproj",
             scheme: "iosApp",
             configuration: "Release",
             export_method: "app-store",
-            # Let Xcode create/refresh the App Store distribution profile via the API key.
-            xcargs: "MARKETING_VERSION=#{marketingVersion} CURRENT_PROJECT_VERSION=#{build_number} -allowProvisioningUpdates"
+            xcargs: "MARKETING_VERSION=#{marketingVersion} CURRENT_PROJECT_VERSION=#{build_number} " \
+                    "-allowProvisioningUpdates " \
+                    "-authenticationKeyPath #{auth_key_file.path} " \
+                    "-authenticationKeyID #{ENV.fetch('ASC_KEY_ID')} " \
+                    "-authenticationKeyIssuerID #{ENV.fetch('ASC_ISSUER_ID')}"
         )
+
+        auth_key_file.unlink
 
         upload_to_testflight(
             api_key: api_key,


### PR DESCRIPTION
## Summary
Same fix as joreilly/Confetti#1784, found while setting up the equivalent flow there.

- `app_store_connect_api_key` (used by `upload_to_testflight`) only authenticates fastlane's own API calls — it never reached `xcodebuild`'s automatic code signing during `build_app`/`archive`.
- On a CI runner with no Apple ID signed into Xcode, `-allowProvisioningUpdates` alone fails archiving with `No Accounts` / `No profiles ... found`. `publish-ios.yml` here has never actually been run (`gh run list` shows zero runs), so this was a latent, untested gap.
- Fix: write the ASC API key to a temp `.p8` and pass it to `xcodebuild` directly via `-authenticationKeyPath`/`-authenticationKeyID`/`-authenticationKeyIssuerID`, so automatic signing can use the key with no Apple ID session at all.
- Also corrected a comment: the API key needs **Admin** role, not just App Manager — App Manager can't drive Xcode's Cloud Managed Signing (hits "Cloud signing permission error" / "No signing certificate found" on export), confirmed by hitting this exact error in Confetti before upgrading the key role.

Note: `publish-ios.yml` still needs `ASC_KEY_ID`/`ASC_ISSUER_ID`/`ASC_KEY_CONTENT` repo secrets configured (none exist on this repo yet) before it can actually run.

## Test plan
- [x] `ruby -c fastlane/Fastfile` — syntax OK
- [ ] Configure ASC secrets, then trigger `publish-ios.yml` to confirm it archives + uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)