### PR TITLE
Point bus markers along the vehicle's heading

### DIFF
--- a/shared/src/androidMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.android.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.android.kt
@@ -3,9 +3,11 @@ package dev.johnoreilly.galwaybus.map
 import android.graphics.Bitmap
 import android.graphics.Canvas as AndroidCanvas
 import android.graphics.Paint
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -20,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -45,7 +48,10 @@ import dev.johnoreilly.galwaybus.displayName
 import dev.johnoreilly.galwaybus.location.UserLocation
 import dev.johnoreilly.galwaybus.model.BusLocation
 import dev.johnoreilly.galwaybus.model.Stop
+import kotlin.math.PI
 import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
 
 private const val GALWAY_LAT = 53.2743
 private const val GALWAY_LON = -9.0488
@@ -175,12 +181,15 @@ actual fun BusMapView(
             val title = if (route != null) "Route $route: ${bus.headsign ?: ""}" else (bus.headsign ?: "Bus")
 
             MarkerComposable(
-                bus.markerKey, markerColor.value, dirIndex, isTracked, routeLabel,
+                bus.markerKey, markerColor.value, dirIndex, isTracked, routeLabel, bus.bearing ?: -1f,
                 state = rememberUpdatedMarkerState(position = LatLng(bus.latitude, bus.longitude)),
+                // Centre the marker on the vehicle rather than resting its base there: the body is
+                // a disc/square, not a pin, and the heading nose has to rotate about that point.
+                anchor = Offset(0.5f, 0.5f),
                 title = title,
                 snippet = bus.vehicle_id?.let { "Vehicle $it" }
             ) {
-                BusMarkerContent(markerColor, routeLabel, dirIndex == 1, isTracked)
+                BusMarkerContent(markerColor, routeLabel, dirIndex == 1, isTracked, bus.bearing)
             }
         }
 
@@ -195,31 +204,81 @@ actual fun BusMapView(
     }
 }
 
-/** A route-coloured marker: circle for direction 0, rounded square for direction 1. */
+/**
+ * A route-coloured marker: circle for direction 0, rounded square for direction 1, with a nose
+ * pointing along [bearing] (degrees clockwise from north) when the feed supplies one.
+ */
 @Composable
-private fun BusMarkerContent(color: Color, routeLabel: String, isSquare: Boolean, isTracked: Boolean) {
+private fun BusMarkerContent(
+    color: Color,
+    routeLabel: String,
+    isSquare: Boolean,
+    isTracked: Boolean,
+    bearing: Float?
+) {
     val contentColor = if (color.luminance() > 0.5f) Color(0xFF1A1A1A) else Color.White
     val shape = if (isSquare) RoundedCornerShape(6.dp) else CircleShape
     Box(
         modifier = Modifier
-            .size(if (isTracked) 44.dp else 36.dp)
-            .background(
-                color = if (isTracked) Color(0x4D4F0000) else Color.Transparent,
-                shape = CircleShape
-            ),
+            // Sized for the nose to stick out past the halo; the body below stays 30.dp either way.
+            .size(if (isTracked) 56.dp else 48.dp),
         contentAlignment = Alignment.Center
     ) {
+        bearing?.let { HeadingNose(it, color) }
         Box(
-            modifier = Modifier.size(30.dp).background(color, shape),
+            modifier = Modifier
+                .size(if (isTracked) 44.dp else 36.dp)
+                .background(
+                    color = if (isTracked) Color(0x4D4F0000) else Color.Transparent,
+                    shape = CircleShape
+                ),
             contentAlignment = Alignment.Center
         ) {
-            Text(
-                text = routeLabel.ifEmpty { "•" },
-                color = contentColor,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Bold
-            )
+            Box(
+                modifier = Modifier.size(30.dp).background(color, shape),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = routeLabel.ifEmpty { "•" },
+                    color = contentColor,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
         }
+    }
+}
+
+/**
+ * Triangle pointing the way the vehicle is travelling, drawn behind the marker body so its base is
+ * hidden. NTA quantises bearing to 45-degree steps, so this is an 8-point indicator.
+ */
+@Composable
+private fun HeadingNose(bearing: Float, color: Color) {
+    Canvas(Modifier.fillMaxSize()) {
+        val cx = size.width / 2f
+        val cy = size.height / 2f
+        val r = 15.dp.toPx() // half the 30.dp body
+        val rad = bearing * (PI / 180f).toFloat()
+        val fx = sin(rad)
+        val fy = -cos(rad)
+        val half = 7.dp.toPx()
+        // Perpendicular to the heading, for the two base corners.
+        val px = -fy * half
+        val py = fx * half
+        val tipX = cx + fx * (r + 9.dp.toPx())
+        val tipY = cy + fy * (r + 9.dp.toPx())
+        val baseX = cx + fx * (r - 3.dp.toPx())
+        val baseY = cy + fy * (r - 3.dp.toPx())
+        drawPath(
+            Path().apply {
+                moveTo(tipX, tipY)
+                lineTo(baseX + px, baseY + py)
+                lineTo(baseX - px, baseY - py)
+                close()
+            },
+            color
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.kt
@@ -466,6 +466,32 @@ internal fun OsmBusMapView(
                     }
 
                     val r = 20f
+                    // Heading nose, drawn under the body so its base is tucked behind the shape.
+                    // The feed's bearing is 8-point (45-degree steps), so this reads as a rough
+                    // "which way is it facing", not a precise angle.
+                    bus.bearing?.let { deg ->
+                        fun nose(dx: Float, dy: Float): Path {
+                            val rad = deg * (PI / 180f).toFloat()
+                            val fx = sin(rad)
+                            val fy = -cos(rad)
+                            val tipX = bx + dx + fx * (r + 12f)
+                            val tipY = by + dy + fy * (r + 12f)
+                            val baseX = bx + dx + fx * (r - 4f)
+                            val baseY = by + dy + fy * (r - 4f)
+                            // Perpendicular to the heading, for the two base corners.
+                            val px = -fy * 9f
+                            val py = fx * 9f
+                            return Path().apply {
+                                moveTo(tipX, tipY)
+                                lineTo(baseX + px, baseY + py)
+                                lineTo(baseX - px, baseY - py)
+                                close()
+                            }
+                        }
+                        drawPath(nose(2f, 2f), Color(0x99000000))
+                        drawPath(nose(0f, 0f), markerColor)
+                    }
+
                     if (dirIndex == 1) {
                         // Second direction: rounded square
                         val side = Size(r * 2, r * 2)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/model/GalwayBusModels.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/model/GalwayBusModels.kt
@@ -49,6 +49,9 @@ data class DepartureTime(
 data class BusLocation(
     val latitude: Double,
     val longitude: Double,
+    /** Compass heading in degrees (0 = north, clockwise) where the feed supplies one, else null.
+     *  NTA quantises it to 45-degree steps, so it is 8-point rather than smooth. */
+    val bearing: Float? = null,
     val modified_timestamp: String,
     val trip_duid: String,
     val vehicle_id: String? = null,

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
@@ -27,7 +27,12 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGAffineTransformIdentity
+import platform.CoreGraphics.CGAffineTransformMakeRotation
 import platform.CoreGraphics.CGAffineTransformMakeScale
+import platform.CoreGraphics.CGPointMake
+import platform.CoreGraphics.CGRectGetHeight
+import platform.CoreGraphics.CGRectGetWidth
+import platform.CoreGraphics.CGRectMake
 import platform.CoreLocation.CLLocationCoordinate2DMake
 import platform.MapKit.MKAnnotationView
 import platform.MapKit.MKCoordinateRegionMakeWithDistance
@@ -40,7 +45,12 @@ import platform.MapKit.MKMarkerAnnotationView
 import platform.MapKit.MKPointAnnotation
 import platform.MapKit.MKUserLocation
 import platform.UIKit.UIColor
+import platform.UIKit.UILabel
+import platform.UIKit.UIView
+import platform.UIKit.NSTextAlignmentCenter
+import platform.UIKit.UIFont
 import platform.darwin.NSObject
+import kotlin.math.PI
 import kotlin.math.abs
 
 private const val GALWAY_LAT = 53.2743
@@ -152,6 +162,47 @@ private fun BusInfoCard(bus: BusLocation, modifier: Modifier = Modifier) {
 /** MKPointAnnotation carrying the bus (for the info card) and its display colour/glyph. */
 private class BusAnnotation(val color: UIColor, val glyph: String?, var busLocation: BusLocation) : MKPointAnnotation()
 
+/** Tag identifying the heading-nose subview, so a recycled annotation view can drop the old one. */
+private const val HEADING_NOSE_TAG = 0x8B5
+
+/** How far the marker balloon's centre sits above the annotation view's own vertical midpoint. */
+private const val BALLOON_CENTRE_LIFT = 10.0
+
+/**
+ * Points a small triangle the way the vehicle is travelling. MapKit has no equivalent of the other
+ * renderers' drawn nose, so it rides as a subview that orbits the marker: the container is centred
+ * on the view and rotated, carrying the glyph at its top edge around with it. NTA quantises bearing
+ * to 45-degree steps, so this is an 8-point indicator.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun MKAnnotationView.applyHeadingNose(bearing: Float?, color: UIColor) {
+    viewWithTag(HEADING_NOSE_TAG.toLong())?.removeFromSuperview()
+    if (bearing == null) return
+    val orbit = 42.0 // diameter; the nose then sits just off the balloon's edge, not floating
+    // MapKit may not have laid the view out yet, in which case its bounds are empty — fall back to
+    // MKMarkerAnnotationView's own default size so the nose still orbits the balloon.
+    val hostWidth = CGRectGetWidth(bounds).takeIf { it > 0.0 } ?: 40.0
+    val hostHeight = CGRectGetHeight(bounds).takeIf { it > 0.0 } ?: 40.0
+    val container = UIView(frame = CGRectMake(0.0, 0.0, orbit, orbit)).apply {
+        tag = HEADING_NOSE_TAG.toLong()
+        userInteractionEnabled = false
+        // The view's vertical midpoint sits below the balloon, because the bounds also cover the
+        // pin tip; lift the orbit so the nose circles the balloon rather than the whole pin.
+        setCenter(CGPointMake(hostWidth / 2.0, hostHeight / 2.0 - BALLOON_CENTRE_LIFT))
+    }
+    val glyphSize = 16.0
+    UILabel(frame = CGRectMake((orbit - glyphSize) / 2.0, 0.0, glyphSize, glyphSize)).apply {
+        text = "\u25B2" // black up-pointing triangle
+        font = UIFont.boldSystemFontOfSize(13.0)
+        textColor = color
+        textAlignment = NSTextAlignmentCenter
+        container.addSubview(this)
+    }
+    container.transform = CGAffineTransformMakeRotation(bearing * PI / 180.0)
+    addSubview(container)
+    sendSubviewToBack(container)
+}
+
 /** MKPointAnnotation carrying the stop it represents (for tap handling) and tracked state. */
 private class StopAnnotation(val stop: Stop, val tracked: Boolean) : MKPointAnnotation()
 
@@ -197,8 +248,12 @@ private class BusMapController {
                     view.titleVisibility = MKFeatureVisibility.MKFeatureVisibilityHidden
                     view.subtitleVisibility = MKFeatureVisibility.MKFeatureVisibilityHidden
                     view.transform = CGAffineTransformIdentity.readValue()
+                    view.applyHeadingNose(viewForAnnotation.busLocation.bearing, viewForAnnotation.color)
                 }
                 is StopAnnotation -> {
+                    // Bus and stop annotations share a reuse pool, so drop any nose the recycled
+                    // view was carrying from its last life as a bus.
+                    view.applyHeadingNose(null, STOP_COLOR)
                     view.markerTintColor = if (viewForAnnotation.tracked) TRACKED_STOP_COLOR else STOP_COLOR
                     view.glyphText = null
                     view.displayPriority = MKFeatureDisplayPriorityDefaultLow
@@ -260,8 +315,12 @@ private class BusMapController {
                 busAnnotations[bus.markerKey] = annotation
                 mapView.addAnnotation(annotation)
             } else {
+                val turned = existing.busLocation.bearing != bus.bearing
                 existing.busLocation = bus
                 existing.setCoordinate(CLLocationCoordinate2DMake(bus.latitude, bus.longitude))
+                if (turned) {
+                    mapView.viewForAnnotation(existing)?.applyHeadingNose(bus.bearing, existing.color)
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

The NTA Vehicles feed supplies a compass bearing for every Galway vehicle (18/18 when checked), which the backend was parsing and then discarding. [GalwayBusBackend#6](https://github.com/joreilly/GalwayBusBackend/pull/6) passes it through; this draws it.

Each bus marker gains a nose pointing the way it is travelling, on all three renderers — the Compose canvas (desktop/web), Google Maps (Android) and MapKit (iOS). Colour-per-route and shape-per-direction are unchanged, so this adds information rather than replacing the existing encoding. The feed quantises bearing to 45° steps, so it reads as an 8-point heading rather than a precise angle.

Two platform details worth flagging in review:

- **Android** — the bus marker anchor moves from the default `(0.5, 1.0)` to `(0.5, 0.5)`. It was resting its base on the coordinate like a pin, which is wrong for a disc and would have put the nose in orbit around the wrong point.
- **iOS** — MapKit exposes no drawing hook on `MKMarkerAnnotationView`, so the nose is a rotated subview. Its orbit is lifted 10pt because the annotation view's bounds include the pin tip, which puts the view's centre below the balloon's.

## Test plan

- [x] `:shared:compileKotlinIosArm64`, `:shared:compileKotlinIosSimulatorArm64`, `:webApp:compileKotlinWasmJs`, `:desktopApp:compileKotlin`, `:androidApp:assembleDebug` — all green
- [x] `:shared:jvmTest` — 26/26
- [x] Rendering checked visually on all three renderers, not just compiled: desktop app, Android emulator, iOS simulator (screenshots reviewed; iOS geometry took two passes to sit against the balloon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uucVCGLGoR4gpqkxNMzT