### PR TITLE
Draw the route on the map, with predicted times at each stop

### DIFF
--- a/shared/src/androidMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.android.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.android.kt
@@ -5,8 +5,13 @@ import android.graphics.Canvas as AndroidCanvas
 import android.graphics.Paint
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -42,6 +47,7 @@ import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.MapsComposeExperimentalApi
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MarkerComposable
+import com.google.maps.android.compose.Polyline
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberUpdatedMarkerState
 import dev.johnoreilly.galwaybus.displayName
@@ -52,6 +58,10 @@ import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.sin
+
+/** Route line: dark enough on the light map style, bright enough on the night one. */
+private val ROUTE_LINE_COLOR = Color(0xFF1565C0)
+private val ETA_TEXT_COLOR = Color(0xFF7B1FA2)
 
 private const val GALWAY_LAT = 53.2743
 private const val GALWAY_LON = -9.0488
@@ -81,7 +91,9 @@ actual fun BusMapView(
     trackedTripId: String?,
     trackedStopRef: String?,
     onStopClick: ((Stop) -> Unit)?,
-    userLocation: UserLocation?
+    userLocation: UserLocation?,
+    polylines: List<List<MapPoint>>,
+    stopEtas: Map<String, StopEta>
 ) {
     val dark = isSystemInDarkTheme()
     val cameraPositionState = rememberCameraPositionState {
@@ -155,20 +167,46 @@ actual fun BusMapView(
         val stopDot = remember { dotDescriptor(30, 0xFF37474F.toInt(), 0xFFFFFFFF.toInt()) }
         val trackedDot = remember { dotDescriptor(40, 0xFF4F0000.toInt(), 0xFFFFFFFF.toInt()) }
 
+        polylines.forEach { line ->
+            if (line.size >= 2) {
+                val points = line.map { LatLng(it.lat, it.lon) }
+                // A pale casing under the line keeps it legible over both map styles.
+                Polyline(points = points, color = Color.White.copy(alpha = 0.7f), width = 20f)
+                Polyline(points = points, color = ROUTE_LINE_COLOR, width = 11f)
+            }
+        }
+
         stops.forEach { stop ->
             val isTracked = stop.stop_ref == trackedStopRef
+            val eta = stopEtas[stop.stop_ref]
             if (isTracked || showStops) {
-                Marker(
-                    state = rememberUpdatedMarkerState(position = LatLng(stop.latitude, stop.longitude)),
-                    icon = if (isTracked) trackedDot else stopDot,
-                    anchor = Offset(0.5f, 0.5f),
-                    title = stop.displayName(),
-                    snippet = "Stop ${stop.stop_id}",
-                    onClick = {
-                        onStopClick?.invoke(stop)
-                        true
+                if (eta != null) {
+                    MarkerComposable(
+                        stop.stop_ref, eta.label, eta.upcoming, isTracked,
+                        state = rememberUpdatedMarkerState(position = LatLng(stop.latitude, stop.longitude)),
+                        anchor = Offset(0.5f, 0.5f),
+                        title = stop.displayName(),
+                        snippet = "Stop ${stop.stop_id}",
+                        onClick = {
+                            onStopClick?.invoke(stop)
+                            true
+                        }
+                    ) {
+                        StopWithEtaContent(eta, isTracked)
                     }
-                )
+                } else {
+                    Marker(
+                        state = rememberUpdatedMarkerState(position = LatLng(stop.latitude, stop.longitude)),
+                        icon = if (isTracked) trackedDot else stopDot,
+                        anchor = Offset(0.5f, 0.5f),
+                        title = stop.displayName(),
+                        snippet = "Stop ${stop.stop_id}",
+                        onClick = {
+                            onStopClick?.invoke(stop)
+                            true
+                        }
+                    )
+                }
             }
         }
 
@@ -278,6 +316,41 @@ private fun HeadingNose(bearing: Float, color: Color) {
                 close()
             },
             color
+        )
+    }
+}
+
+/**
+ * A stop dot with its predicted departure beside it. Composed rather than drawn into a bitmap so
+ * the text picks up the app's typography, and anchored centrally so the dot stays on the stop.
+ */
+@Composable
+private fun StopWithEtaContent(eta: StopEta, isTracked: Boolean) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(if (isTracked) 16.dp else 11.dp)
+                .background(
+                    color = when {
+                        isTracked -> Color(0xFF4F0000)
+                        // Muted once the bus is past: still on the trip, nothing left to wait for.
+                        !eta.upcoming -> Color(0xFF9E9E9E)
+                        else -> Color(0xFF37474F)
+                    },
+                    shape = CircleShape
+                )
+                .border(width = 1.5.dp, color = Color.White, shape = CircleShape)
+        )
+        if (eta.label.isBlank()) return@Row  // passed stop: muted dot, nothing to annotate
+        Spacer(Modifier.width(3.dp))
+        Text(
+            text = eta.label,
+            color = if (eta.upcoming) ETA_TEXT_COLOR else Color(0xFF757575),
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier
+                .background(Color.White.copy(alpha = 0.85f), RoundedCornerShape(3.dp))
+                .padding(horizontal = 3.dp, vertical = 1.dp)
         )
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
@@ -53,6 +53,7 @@ import com.pushpal.jetlime.JetLimeEventDefaults
 import com.pushpal.jetlime.JetLimeExtendedEvent
 import dev.johnoreilly.galwaybus.location.NearbyStop
 import dev.johnoreilly.galwaybus.map.BusMapView
+import dev.johnoreilly.galwaybus.map.StopEta
 import androidx.compose.ui.graphics.Color
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
@@ -68,6 +69,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import kotlin.time.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.pluralStringResource
@@ -189,6 +192,36 @@ private val visibleTopTabs: List<TopTab> =
 
 private enum class Screen {
     MAIN, TRACKING
+}
+
+/**
+ * Predicted departure per stop for the trip being tracked, for labelling the line on the map.
+ *
+ * The bus only reports the stops still ahead of it, so a stop on the trip with no entry is one it
+ * has already passed: those get a muted marker and no time, since there is nothing left to wait
+ * for and we have no prediction for them anyway. With no bus in the feed there is nothing to say,
+ * and every stop is left plain.
+ */
+internal fun stopEtasFor(trackedBus: BusLocation?, stops: List<Stop>): Map<String, StopEta> {
+    val ahead = trackedBus?.next_stops.orEmpty()
+    val predicted = ahead.mapNotNull { p -> p.departure_timestamp?.let { p.stop_ref to it } }.toMap()
+    val aheadRefs = ahead.map { it.stop_ref }.toSet()
+    return stops.mapNotNull { stop ->
+        val label = predicted[stop.stop_ref]?.let { clockLabel(it) }
+        when {
+            label != null -> stop.stop_ref to StopEta(label, upcoming = true)
+            trackedBus != null && stop.stop_ref !in aheadRefs -> stop.stop_ref to StopEta("", upcoming = false)
+            else -> null
+        }
+    }.toMap()
+}
+
+/** An ISO timestamp as a local clock time ("16:52"), for labelling stops on the map. */
+private fun clockLabel(isoTimestamp: String): String? = try {
+    val local = Instant.parse(isoTimestamp).toLocalDateTime(TimeZone.currentSystemDefault())
+    "${local.hour.toString().padStart(2, '0')}:${local.minute.toString().padStart(2, '0')}"
+} catch (e: Exception) {
+    null
 }
 
 /** Bare countdown to the (live-adjusted) departure. Returns "Due", "3 min", "1h 5min", "N/A". */
@@ -903,13 +936,26 @@ private fun BusTrackingView(
         val timelineStops = routeStops.firstOrNull { dir -> dir.any { it.stop_ref == trackedStopRef } }
             ?: routeStops.firstOrNull().orEmpty()
 
+        // The bus knows which shape variant it is driving; until it appears in the feed, its
+        // direction's line stands in.
+        val trackedBus = displayPositions.firstOrNull()
+        LaunchedEffect(trackedBus?.shape_id) { viewModel.loadTrackedShape(trackedBus?.shape_id) }
+        val trackedShape by viewModel.trackedShape.collectAsStateWithLifecycle()
+        val routeShapes by viewModel.routeShapes.collectAsStateWithLifecycle()
+        val directionShape = routeShapes.getOrNull(routeStops.indexOf(timelineStops)).orEmpty()
+        val tripLine = trackedShape.ifEmpty { directionShape }
+
+        val stopEtas = remember(trackedBus, timelineStops) { stopEtasFor(trackedBus, timelineStops) }
+
         val mapArea: @Composable (Modifier) -> Unit = { m ->
             Box(m) {
                 BusMapView(
                     positions = displayPositions,
-                    stops = trackedStop,
+                    stops = timelineStops,
                     trackedTripId = trackedBusTripId,
                     trackedStopRef = trackedStopRef,
+                    polylines = if (tripLine.isEmpty()) emptyList() else listOf(tripLine),
+                    stopEtas = stopEtas,
                     modifier = Modifier.fillMaxSize()
                 )
                 TrackingInfoCard(
@@ -1715,12 +1761,18 @@ private fun DetailPane(
         )
         ViewMode.MAP -> Box(modifier) {
             key(selectedRouteNum) {
+                val routeShapes by viewModel.routeShapes.collectAsStateWithLifecycle()
                 BusMapView(
                     positions = busPositions,
                     stops = routeStops.flatten().distinctBy { it.stop_ref },
                     trackedTripId = viewModel.trackedTripId,
                     trackedStopRef = viewModel.trackedStopRef,
                     onStopClick = { viewModel.selectMapStop(it) },
+                    // Only the direction on screen, so the two lines don't overdraw each other.
+                    polylines = routeShapes.getOrNull(viewModel.selectedDirection)
+                        ?.takeIf { it.isNotEmpty() }
+                        ?.let { listOf(it) }
+                        .orEmpty(),
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
@@ -932,9 +932,13 @@ private fun BusTrackingView(
             )
         }
     ) { padding ->
-        // Stops for the direction the tracked stop belongs to (fall back to the first direction).
-        val timelineStops = routeStops.firstOrNull { dir -> dir.any { it.stop_ref == trackedStopRef } }
-            ?: routeStops.firstOrNull().orEmpty()
+        // The direction the tracked stop belongs to (fall back to the first). Held as an index so
+        // the stop list and its geometry are read from the same place, rather than recovering the
+        // index later by comparing whole stop lists for equality on every recomposition.
+        val directionIndex = routeStops
+            .indexOfFirst { dir -> dir.any { it.stop_ref == trackedStopRef } }
+            .takeIf { it >= 0 } ?: 0
+        val timelineStops = routeStops.getOrNull(directionIndex).orEmpty()
 
         // The bus knows which shape variant it is driving; until it appears in the feed, its
         // direction's line stands in.
@@ -942,7 +946,7 @@ private fun BusTrackingView(
         LaunchedEffect(trackedBus?.shape_id) { viewModel.loadTrackedShape(trackedBus?.shape_id) }
         val trackedShape by viewModel.trackedShape.collectAsStateWithLifecycle()
         val routeShapes by viewModel.routeShapes.collectAsStateWithLifecycle()
-        val directionShape = routeShapes.getOrNull(routeStops.indexOf(timelineStops)).orEmpty()
+        val directionShape = routeShapes.getOrNull(directionIndex).orEmpty()
         val tripLine = trackedShape.ifEmpty { directionShape }
 
         val stopEtas = remember(trackedBus, timelineStops) { stopEtasFor(trackedBus, timelineStops) }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
@@ -34,6 +34,7 @@ class GalwayBusRepository(
     private var routesCache: Map<String, Route>? = null
     private var stopsCache: List<Stop>? = null
     private val routeDetailsCache = mutableMapOf<String, ApiRouteDetails>()
+    private val shapeCache = mutableMapOf<String, List<List<Double>>>()
 
     // RT caches: epochMs timestamp paired with data
     private val vehiclesMutex = Mutex()
@@ -184,6 +185,20 @@ class GalwayBusRepository(
      */
     suspend fun getRouteShapes(routeNum: String): List<List<List<Double>>> =
         routeDetails(routeNum).shapes
+
+    /**
+     * A single shape's geometry. Shapes are shared by many trips and identical across snapshots,
+     * so one fetch per id serves every trip that drives it.
+     */
+    suspend fun getShape(shapeId: String): List<List<Double>> = staticMutex.withLock {
+        shapeCache[shapeId]?.let { return it }
+        val points = try {
+            httpClient.get("$backendUrl/shapes/$shapeId").body<List<List<Double>>>()
+        } catch (e: Exception) {
+            emptyList()
+        }
+        points.also { if (it.isNotEmpty()) shapeCache[shapeId] = it }
+    }
 
     private suspend fun routeDetails(routeNum: String): ApiRouteDetails = staticMutex.withLock {
         routeDetailsCache[routeNum]?.let { return it }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusViewModel.kt
@@ -10,6 +10,8 @@ import dev.johnoreilly.galwaybus.location.LocationResult
 import dev.johnoreilly.galwaybus.location.NearbyStop
 import dev.johnoreilly.galwaybus.location.UserLocation
 import dev.johnoreilly.galwaybus.location.nearestTo
+import dev.johnoreilly.galwaybus.map.MapPoint
+import dev.johnoreilly.galwaybus.map.toMapPoints
 import dev.johnoreilly.galwaybus.model.BusLocation
 import dev.johnoreilly.galwaybus.model.DepartureTime
 import dev.johnoreilly.galwaybus.model.FavouriteStop
@@ -78,6 +80,14 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
 
     private val _routeStops = MutableStateFlow<List<List<Stop>>>(emptyList())
     val routeStops: StateFlow<List<List<Stop>>> = _routeStops.asStateFlow()
+
+    // Road geometry per direction for the selected route, index-aligned with routeStops, and the
+    // tracked trip's own line (which can be a variant of its direction's).
+    private val _routeShapes = MutableStateFlow<List<List<MapPoint>>>(emptyList())
+    val routeShapes: StateFlow<List<List<MapPoint>>> = _routeShapes.asStateFlow()
+
+    private val _trackedShape = MutableStateFlow<List<MapPoint>>(emptyList())
+    val trackedShape: StateFlow<List<MapPoint>> = _trackedShape.asStateFlow()
 
     private val _directionHeadsigns = MutableStateFlow<List<String>>(emptyList())
     val directionHeadsigns: StateFlow<List<String>> = _directionHeadsigns.asStateFlow()
@@ -367,6 +377,21 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
         }
     }
 
+    /**
+     * Loads the tracked bus's own geometry once its vehicle appears in the feed. Trips on a route
+     * run several shape variants (short workings, diversions), so the direction's line is only a
+     * stand-in until the bus tells us which one it is driving.
+     */
+    fun loadTrackedShape(shapeId: String?) {
+        if (shapeId == null || shapeId == loadedTrackedShapeId) return
+        loadedTrackedShapeId = shapeId
+        viewModelScope.launch {
+            _trackedShape.value = repository.getShape(shapeId).toMapPoints()
+        }
+    }
+
+    private var loadedTrackedShapeId: String? = null
+
     fun setTrackedDeparture(departure: DepartureTime, stopRef: String) {
         trackedTripId = departure.tripId
         trackedStopRef = stopRef
@@ -377,6 +402,8 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
     fun clearTrackedDeparture() {
         trackedTripId = null
         trackedStopRef = null
+        loadedTrackedShapeId = null
+        _trackedShape.value = emptyList()
         trackedDeparture = null
     }
 
@@ -399,6 +426,7 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
             try {
                 _routeStops.value = repository.getStopsForRoute(routeNum)
                 _directionHeadsigns.value = repository.getDirectionHeadsigns(routeNum)
+                _routeShapes.value = repository.getRouteShapes(routeNum).map { it.toMapPoints() }
                 val fetched = repository.getBusPositions(routeNum)
                 _busPositions.value = fetched
                 if (fetched.isNotEmpty()) lastNonEmptyRouteBusesMs = nowEpochMilliseconds()

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.kt
@@ -64,6 +64,10 @@ private data class TileId(val z: Int, val x: Int, val y: Int)
 private data class LatLon(val lat: Double, val lon: Double)
 
 // invert + hue-rotate(180°): tiles go dark while land/water/road hues stay roughly true
+/** Route line: dark enough to read on light tiles, bright enough on the dark ones. */
+private val ROUTE_LINE_COLOR = Color(0xFF1565C0)
+private val ETA_TEXT_COLOR = Color(0xFF7B1FA2)
+
 private val DarkTileFilter = ColorFilter.colorMatrix(
     ColorMatrix(
         floatArrayOf(
@@ -106,7 +110,9 @@ internal fun OsmBusMapView(
     trackedTripId: String? = null,
     trackedStopRef: String? = null,
     onStopClick: ((Stop) -> Unit)? = null,
-    userLocation: UserLocation? = null
+    userLocation: UserLocation? = null,
+    polylines: List<List<MapPoint>> = emptyList(),
+    stopEtas: Map<String, StopEta> = emptyMap()
 ) {
     val tileClient = remember { HttpClient() }
     val tileImages = remember { mutableStateMapOf<TileId, ImageBitmap>() }
@@ -253,6 +259,14 @@ internal fun OsmBusMapView(
     val routeLabelLayouts = remember(positions, textMeasurer, labelStyle) {
         positions.mapNotNull { it.timetable_id }.filter { it.isNotEmpty() }.distinct()
             .associateWith { route -> textMeasurer.measure(AnnotatedString(route), labelStyle) }
+    }
+    val etaStyle = with(LocalDensity.current) {
+        TextStyle(fontSize = 12f.toSp(), fontWeight = FontWeight.Bold)
+    }
+    val etaLayouts = remember(stopEtas, textMeasurer, etaStyle) {
+        // Passed stops carry an empty label — they are muted, not annotated.
+        stopEtas.filterValues { it.label.isNotBlank() }
+            .mapValues { (_, eta) -> textMeasurer.measure(AnnotatedString(eta.label), etaStyle) }
     }
 
     Box(modifier.clipToBounds()) {
@@ -435,6 +449,22 @@ internal fun OsmBusMapView(
                     drawImage(bitmap, topLeft = Offset(px, py), colorFilter = tileColorFilter)
                 }
 
+                // Road geometry, under the markers so it never hides one. Points are projected the
+                // same way as markers, so the line stays glued to the map through zoom and pan.
+                polylines.forEach { line ->
+                    if (line.size < 2) return@forEach
+                    val path = Path()
+                    line.forEachIndexed { i, point ->
+                        val px = ((lonToTileXf(point.lon, zoom) - originTileXf) * TILE_PX).toFloat()
+                        val py = ((latToTileYf(point.lat, zoom) - originTileYf) * TILE_PX).toFloat()
+                        if (i == 0) path.moveTo(px, py) else path.lineTo(px, py)
+                    }
+                    // Drawn twice: a pale casing first, so the line reads against both the light
+                    // and dark tile sets without a per-theme colour.
+                    drawPath(path, Color.White.copy(alpha = 0.7f), style = Stroke(width = 9f))
+                    drawPath(path, ROUTE_LINE_COLOR, style = Stroke(width = 5f))
+                }
+
                 stops.forEach { stop ->
                     val isTracked = stop.stop_ref == trackedStopRef
                     if (zoom >= STOP_MARKER_MIN_ZOOM || isTracked) {
@@ -443,11 +473,34 @@ internal fun OsmBusMapView(
                         if (sx in -16f..size.width + 16f && sy in -16f..size.height + 16f) {
                             val radius = if (isTracked) 16f else 11f
                             val color = if (isTracked) Color(0xFF4f0000) else Color(0xFF37474F)
-                            drawCircle(color, radius = radius, center = Offset(sx, sy))
+                            val eta = stopEtas[stop.stop_ref]
+                            val dotColor = when {
+                                isTracked -> Color(0xFF4f0000)
+                                // Muted once the bus is past it: the stop is still on the trip,
+                                // but there is nothing left to wait for.
+                                eta != null && !eta.upcoming -> Color(0xFF9E9E9E)
+                                else -> Color(0xFF37474F)
+                            }
+                            drawCircle(dotColor, radius = radius, center = Offset(sx, sy))
                             drawCircle(
                                 Color.White, radius = radius,
                                 center = Offset(sx, sy), style = Stroke(width = 2.5f)
                             )
+                            etaLayouts[stop.stop_ref]?.let { layout ->
+                                val lx = sx + radius + 5f
+                                val ly = sy - layout.size.height / 2f
+                                drawRoundRect(
+                                    color = Color.White.copy(alpha = 0.85f),
+                                    topLeft = Offset(lx - 3f, ly - 2f),
+                                    size = Size(layout.size.width + 6f, layout.size.height + 4f),
+                                    cornerRadius = CornerRadius(4f, 4f)
+                                )
+                                drawText(
+                                    layout,
+                                    color = if (eta?.upcoming == false) Color(0xFF757575) else ETA_TEXT_COLOR,
+                                    topLeft = Offset(lx, ly)
+                                )
+                            }
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/PlatformBusMapView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/PlatformBusMapView.kt
@@ -6,6 +6,21 @@ import dev.johnoreilly.galwaybus.location.UserLocation
 import dev.johnoreilly.galwaybus.model.BusLocation
 import dev.johnoreilly.galwaybus.model.Stop
 
+/** A point on a drawn line. The API sends geometry as [lat, lon] pairs; this names them. */
+data class MapPoint(val lat: Double, val lon: Double)
+
+/**
+ * A stop's predicted departure, drawn beside it on the map.
+ *
+ * @param label the time to show, already formatted for display (e.g. "16:52").
+ * @param upcoming false once the bus has passed the stop, so it can be drawn muted.
+ */
+data class StopEta(val label: String, val upcoming: Boolean)
+
+/** Geometry as the API sends it — [lat, lon] pairs — as points. */
+fun List<List<Double>>.toMapPoints(): List<MapPoint> =
+    mapNotNull { p -> if (p.size >= 2) MapPoint(p[0], p[1]) else null }
+
 /**
  * The bus map. Each platform provides a native implementation:
  *  - Android → Google Maps (maps-compose)
@@ -18,6 +33,9 @@ import dev.johnoreilly.galwaybus.model.Stop
  * @param trackedStopRef when set, the map centres/highlights this stop.
  * @param onStopClick invoked when a stop marker is tapped (opens its departures sheet).
  * @param userLocation the device's location, shown as a "you are here" marker.
+ * @param polylines road geometry to trace — the path a bus actually drives, rather than straight
+ *   lines between its stops. Usually one line: the tracked trip's, or the shown direction's.
+ * @param stopEtas predicted departure per stop_ref, drawn beside that stop's marker.
  */
 @Composable
 expect fun BusMapView(
@@ -27,5 +45,7 @@ expect fun BusMapView(
     trackedTripId: String? = null,
     trackedStopRef: String? = null,
     onStopClick: ((Stop) -> Unit)? = null,
-    userLocation: UserLocation? = null
+    userLocation: UserLocation? = null,
+    polylines: List<List<MapPoint>> = emptyList(),
+    stopEtas: Map<String, StopEta> = emptyMap()
 )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/model/GalwayBusModels.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/model/GalwayBusModels.kt
@@ -58,7 +58,9 @@ data class BusLocation(
     val timetable_id: String? = null,
     val headsign: String? = null,
     val next_stop_ref: String? = null,
-    val next_stops: List<StopPrediction>? = null
+    val next_stops: List<StopPrediction>? = null,
+    /** The trip's road geometry, fetched from the backend by id and cached; shared by many trips. */
+    val shape_id: String? = null
 )
 
 @Serializable

--- a/shared/src/commonTest/kotlin/dev/johnoreilly/galwaybus/StopEtaTest.kt
+++ b/shared/src/commonTest/kotlin/dev/johnoreilly/galwaybus/StopEtaTest.kt
@@ -1,0 +1,69 @@
+package dev.johnoreilly.galwaybus
+
+import dev.johnoreilly.galwaybus.model.BusLocation
+import dev.johnoreilly.galwaybus.model.Stop
+import dev.johnoreilly.galwaybus.model.StopPrediction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Times drawn beside the stops on the tracked trip's line. The distinction that matters is between
+ * a stop the bus is still coming to and one it has already left: the feed only predicts the former,
+ * so the latter must be shown as passed rather than as "no data".
+ */
+class StopEtaTest {
+
+    private fun stop(ref: String) = Stop(
+        stop_ref = ref, stop_id = ref.takeLast(6), long_name = ref,
+        short_name = ref, latitude = 53.27, longitude = -9.05
+    )
+
+    private val stops = listOf(stop("A"), stop("B"), stop("C"), stop("D"))
+
+    private fun busAt(vararg ahead: Pair<String, String?>) = BusLocation(
+        latitude = 53.27,
+        longitude = -9.05,
+        modified_timestamp = "2026-09-06T17:00:00Z",
+        trip_duid = "trip-1",
+        next_stops = ahead.mapIndexed { i, (ref, time) ->
+            StopPrediction(stop_ref = ref, stop_sequence = i, departure_timestamp = time)
+        }
+    )
+
+    @Test
+    fun `stops ahead are labelled with their predicted time`() {
+        val etas = stopEtasFor(busAt("C" to "2026-09-06T17:05:00Z", "D" to "2026-09-06T17:12:00Z"), stops)
+        assertTrue(etas.getValue("C").upcoming)
+        assertTrue(etas.getValue("D").upcoming)
+        // Formatted as a local clock time; the exact hour depends on the test machine's zone, so
+        // assert the shape rather than the value.
+        assertTrue(etas.getValue("C").label.matches(Regex("""\d{2}:\d{2}""")), "Got '${etas.getValue("C").label}'")
+    }
+
+    @Test
+    fun `stops the bus has passed are marked passed, not merely unknown`() {
+        val etas = stopEtasFor(busAt("C" to "2026-09-06T17:05:00Z", "D" to "2026-09-06T17:12:00Z"), stops)
+        listOf("A", "B").forEach { ref ->
+            val eta = etas[ref]
+            assertTrue(eta != null, "Stop $ref should be marked as passed")
+            assertTrue(!eta.upcoming, "Stop $ref should not be upcoming")
+            assertEquals("", eta.label, "A passed stop has no prediction to show")
+        }
+    }
+
+    @Test
+    fun `an upcoming stop the feed hasn't timed yet is left plain`() {
+        // NTA's predictions are sparse; a stop that is ahead but untimed gets no marker treatment,
+        // rather than being wrongly greyed out as passed.
+        val etas = stopEtasFor(busAt("C" to null, "D" to "2026-09-06T17:12:00Z"), stops)
+        assertNull(etas["C"], "An ahead-but-untimed stop should not be labelled or muted")
+        assertTrue(etas.getValue("D").upcoming)
+    }
+
+    @Test
+    fun `with no bus in the feed nothing is annotated`() {
+        assertTrue(stopEtasFor(null, stops).isEmpty())
+    }
+}

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
@@ -25,6 +25,9 @@ import dev.johnoreilly.galwaybus.model.BusLocation
 import dev.johnoreilly.galwaybus.model.Stop
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCSignatureOverride
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGAffineTransformIdentity
 import platform.CoreGraphics.CGAffineTransformMakeRotation
@@ -33,6 +36,7 @@ import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectGetHeight
 import platform.CoreGraphics.CGRectGetWidth
 import platform.CoreGraphics.CGRectMake
+import platform.CoreLocation.CLLocationCoordinate2D
 import platform.CoreLocation.CLLocationCoordinate2DMake
 import platform.MapKit.MKAnnotationView
 import platform.MapKit.MKCoordinateRegionMakeWithDistance
@@ -42,6 +46,12 @@ import platform.MapKit.MKFeatureVisibility
 import platform.MapKit.MKMapView
 import platform.MapKit.MKMapViewDelegateProtocol
 import platform.MapKit.MKMarkerAnnotationView
+import platform.MapKit.MKOverlayProtocol
+import platform.MapKit.addOverlay
+import platform.MapKit.removeOverlay
+import platform.MapKit.MKOverlayRenderer
+import platform.MapKit.MKPolyline
+import platform.MapKit.MKPolylineRenderer
 import platform.MapKit.MKPointAnnotation
 import platform.MapKit.MKUserLocation
 import platform.UIKit.UIColor
@@ -84,7 +94,9 @@ actual fun BusMapView(
     trackedTripId: String?,
     trackedStopRef: String?,
     onStopClick: ((Stop) -> Unit)?,
-    userLocation: UserLocation?
+    userLocation: UserLocation?,
+    polylines: List<List<MapPoint>>,
+    stopEtas: Map<String, StopEta>
 ) {
     val controller = remember { BusMapController() }
     // markerKey of the bus whose info card is showing (null = none). Cleared when the map
@@ -115,7 +127,7 @@ actual fun BusMapView(
                 controller.onBusClick = { bus -> selectedBusKey = bus.markerKey }
                 controller.onBusDeselect = { selectedBusKey = null }
                 mapView.showsUserLocation = userLocation != null
-                controller.sync(mapView, positions, stops, busColors, trackedTripId, trackedStopRef, userLocation)
+                controller.sync(mapView, positions, stops, busColors, trackedTripId, trackedStopRef, userLocation, polylines, stopEtas)
             }
         )
 
@@ -203,8 +215,39 @@ private fun MKAnnotationView.applyHeadingNose(bearing: Float?, color: UIColor) {
     sendSubviewToBack(container)
 }
 
-/** MKPointAnnotation carrying the stop it represents (for tap handling) and tracked state. */
-private class StopAnnotation(val stop: Stop, val tracked: Boolean) : MKPointAnnotation()
+/** MKPointAnnotation carrying the stop it represents (for tap handling), tracked state and ETA. */
+private class StopAnnotation(
+    val stop: Stop,
+    val tracked: Boolean,
+    val eta: StopEta? = null
+) : MKPointAnnotation()
+
+/** Tag identifying the ETA label subview, so a recycled annotation view drops the previous one. */
+private const val STOP_ETA_TAG = 0x8B6
+
+/**
+ * Writes a stop's predicted departure beside its pin. MapKit's own title is hidden (it renders as
+ * unreadable text over the map), so the label rides as a subview instead.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private fun MKAnnotationView.applyStopEta(eta: StopEta?) {
+    viewWithTag(STOP_ETA_TAG.toLong())?.removeFromSuperview()
+    if (eta == null || eta.label.isBlank()) return  // passed stops are muted, not annotated
+    val width = 46.0
+    val height = 16.0
+    UILabel(frame = CGRectMake(CGRectGetWidth(bounds) / 2.0 + 6.0, -2.0, width, height)).apply {
+        tag = STOP_ETA_TAG.toLong()
+        userInteractionEnabled = false
+        text = eta.label
+        font = UIFont.boldSystemFontOfSize(11.0)
+        textColor = if (eta.upcoming) ETA_TEXT_COLOR else UIColor.grayColor
+        backgroundColor = UIColor.whiteColor.colorWithAlphaComponent(0.85)
+        textAlignment = NSTextAlignmentCenter
+        layer.cornerRadius = 3.0
+        clipsToBounds = true
+        addSubview(this)
+    }
+}
 
 @OptIn(ExperimentalForeignApi::class)
 private fun Color.toUIColor(): UIColor =
@@ -212,6 +255,9 @@ private fun Color.toUIColor(): UIColor =
 
 private val STOP_COLOR = UIColor(red = 0.216, green = 0.278, blue = 0.310, alpha = 1.0) // #37474F
 private val TRACKED_STOP_COLOR = UIColor(red = 0.31, green = 0.0, blue = 0.0, alpha = 1.0)
+private val PASSED_STOP_COLOR = UIColor(red = 0.62, green = 0.62, blue = 0.62, alpha = 1.0)
+private val ROUTE_LINE_COLOR = UIColor(red = 0.082, green = 0.396, blue = 0.753, alpha = 1.0)
+private val ETA_TEXT_COLOR = UIColor(red = 0.482, green = 0.121, blue = 0.635, alpha = 1.0)
 
 /**
  * Owns the annotations currently on the map and reconciles them against the latest data on each
@@ -225,7 +271,33 @@ private class BusMapController {
 
     private val busAnnotations = HashMap<String, BusAnnotation>()
     private val stopAnnotations = HashMap<String, StopAnnotation>()
+    private var overlays: List<MKPolyline> = emptyList()
+    private var overlayKey: String? = null
+    private var stopEtas: Map<String, StopEta> = emptyMap()
     private var hasCentered = false
+
+    /**
+     * Replaces the drawn geometry when it changes. Keyed on the lines themselves so panning and
+     * refreshing don't tear the overlay down and rebuild it every few seconds.
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    private fun syncPolylines(mapView: MKMapView, polylines: List<List<MapPoint>>) {
+        val key = polylines.joinToString("|") { "${it.size}:${it.firstOrNull()?.lat},${it.lastOrNull()?.lon}" }
+        if (key == overlayKey) return
+        overlayKey = key
+        overlays.forEach { mapView.removeOverlay(it) }
+        overlays = polylines.filter { it.size >= 2 }.map { line ->
+            memScoped {
+                val coords = allocArray<CLLocationCoordinate2D>(line.size)
+                line.forEachIndexed { i, p ->
+                    coords[i].latitude = p.lat
+                    coords[i].longitude = p.lon
+                }
+                MKPolyline.polylineWithCoordinates(coords, line.size.toULong())
+            }
+        }
+        overlays.forEach { mapView.addOverlay(it) }
+    }
 
     val delegate: MKMapViewDelegateProtocol = object : NSObject(), MKMapViewDelegateProtocol {
         override fun mapView(
@@ -249,12 +321,17 @@ private class BusMapController {
                     view.subtitleVisibility = MKFeatureVisibility.MKFeatureVisibilityHidden
                     view.transform = CGAffineTransformIdentity.readValue()
                     view.applyHeadingNose(viewForAnnotation.busLocation.bearing, viewForAnnotation.color)
+                    view.applyStopEta(null)
                 }
                 is StopAnnotation -> {
                     // Bus and stop annotations share a reuse pool, so drop any nose the recycled
                     // view was carrying from its last life as a bus.
                     view.applyHeadingNose(null, STOP_COLOR)
-                    view.markerTintColor = if (viewForAnnotation.tracked) TRACKED_STOP_COLOR else STOP_COLOR
+                    view.markerTintColor = when {
+                        viewForAnnotation.tracked -> TRACKED_STOP_COLOR
+                        viewForAnnotation.eta?.upcoming == false -> PASSED_STOP_COLOR
+                        else -> STOP_COLOR
+                    }
                     view.glyphText = null
                     view.displayPriority = MKFeatureDisplayPriorityDefaultLow
                     view.canShowCallout = true // stop name in the callout; tap also opens departures
@@ -263,9 +340,17 @@ private class BusMapController {
                     // Stops are secondary to buses and there are many of them, so keep the markers small.
                     val scale = if (viewForAnnotation.tracked) 0.9 else 0.6
                     view.transform = CGAffineTransformMakeScale(scale, scale)
+                    view.applyStopEta(viewForAnnotation.eta)
                 }
             }
             return view
+        }
+
+        override fun mapView(mapView: MKMapView, rendererForOverlay: MKOverlayProtocol): MKOverlayRenderer {
+            val renderer = MKPolylineRenderer(overlay = rendererForOverlay)
+            renderer.strokeColor = ROUTE_LINE_COLOR
+            renderer.lineWidth = 4.0
+            return renderer
         }
 
         @ObjCSignatureOverride
@@ -289,8 +374,12 @@ private class BusMapController {
         busColors: Map<String, Color>,
         trackedTripId: String?,
         trackedStopRef: String?,
-        userLocation: UserLocation?
+        userLocation: UserLocation?,
+        polylines: List<List<MapPoint>> = emptyList(),
+        stopEtas: Map<String, StopEta> = emptyMap()
     ) {
+        syncPolylines(mapView, polylines)
+        this.stopEtas = stopEtas
         // Distinct headsigns per route → a stable direction index; direction 1 is glyphed "»".
         val routeHeadsigns = positions.groupBy { it.timetable_id ?: "" }
             .mapValues { (_, buses) -> buses.mapNotNull { it.headsign }.distinct().sorted() }
@@ -324,9 +413,10 @@ private class BusMapController {
             }
         }
 
-        // --- Stops: keyed by ref + tracked state (re-add if tracking changed to restyle) ---
+        // --- Stops: keyed by ref + tracked state + ETA (re-add to restyle or relabel) ---
         val stopKeys = stops.associate { it.stop_ref to (it.stop_ref == trackedStopRef) }
-        stopAnnotations.entries.filter { (ref, ann) -> stopKeys[ref] != ann.tracked }
+        stopAnnotations.entries
+            .filter { (ref, ann) -> stopKeys[ref] != ann.tracked || stopEtas[ref] != ann.eta }
             .toList()
             .forEach { (ref, ann) ->
                 stopAnnotations.remove(ref)
@@ -334,7 +424,7 @@ private class BusMapController {
             }
         stops.forEach { stop ->
             if (stopAnnotations[stop.stop_ref] == null) {
-                val annotation = StopAnnotation(stop, stop.stop_ref == trackedStopRef).apply {
+                val annotation = StopAnnotation(stop, stop.stop_ref == trackedStopRef, stopEtas[stop.stop_ref]).apply {
                     setCoordinate(CLLocationCoordinate2DMake(stop.latitude, stop.longitude))
                     setTitle(stop.localizedName())
                     setSubtitle("Stop ${stop.stop_id}")

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.jvm.kt
@@ -15,7 +15,9 @@ actual fun BusMapView(
     trackedTripId: String?,
     trackedStopRef: String?,
     onStopClick: ((Stop) -> Unit)?,
-    userLocation: UserLocation?
+    userLocation: UserLocation?,
+    polylines: List<List<MapPoint>>,
+    stopEtas: Map<String, StopEta>
 ) {
     OsmBusMapView(
         positions = positions,
@@ -24,6 +26,8 @@ actual fun BusMapView(
         trackedTripId = trackedTripId,
         trackedStopRef = trackedStopRef,
         onStopClick = onStopClick,
-        userLocation = userLocation
+        userLocation = userLocation,
+        polylines = polylines,
+        stopEtas = stopEtas
     )
 }

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.wasmJs.kt
@@ -15,7 +15,9 @@ actual fun BusMapView(
     trackedTripId: String?,
     trackedStopRef: String?,
     onStopClick: ((Stop) -> Unit)?,
-    userLocation: UserLocation?
+    userLocation: UserLocation?,
+    polylines: List<List<MapPoint>>,
+    stopEtas: Map<String, StopEta>
 ) {
     OsmBusMapView(
         positions = positions,
@@ -24,6 +26,8 @@ actual fun BusMapView(
         trackedTripId = trackedTripId,
         trackedStopRef = trackedStopRef,
         onStopClick = onStopClick,
-        userLocation = userLocation
+        userLocation = userLocation,
+        polylines = polylines,
+        stopEtas = stopEtas
     )
 }


### PR DESCRIPTION
## Summary

Feature B. Maps drew stops as unconnected dots — a route's actual path was left to the imagination — and the per-stop predictions the backend already sends were only visible in the timeline list beside the map.

`BusMapView` gains `polylines` and `stopEtas`, implemented on all three renderers (Compose canvas for desktop/web, Google Maps, MapKit):

- **Route screen** draws the direction currently on show (not both, so the lines don't overdraw).
- **Tracking screen** draws the trip's own line and labels each stop with its predicted time.

Geometry is fetched by `shape_id` and cached — 93 shapes cover all 10,808 Galway trips, so it's a handful of requests per session. Trips on a route drive several shape variants, so the direction's line stands in until the vehicle appears in the feed and says which one it's actually on.

The subtle bit is what a *missing* prediction means. The bus only reports stops ahead of it, so a stop on the line with no entry is one it has already left: those are drawn muted with no time, rather than looking like missing data. But a stop that is ahead and simply hasn't been timed yet (NTA's predictions are sparse) is left plain — sparse data shouldn't read as "already passed". `StopEtaTest` pins down all three cases.

> ⚠️ Stacked on `client-drop-bundled-snapshot` (#93), which in turn needs GalwayBusBackend #7 deployed — that's where `shape_id`, `/shapes/{id}` and `RouteDetails.shapes` come from. Without it the lines are simply absent; the ETA labels work against prod today.

## Test plan

- [x] All targets compile: both iOS, wasm, desktop, `androidApp:assembleDebug`
- [x] `:shared:jvmTest` — 31/31, including 4 new `StopEtaTest` cases (ahead-and-timed → labelled; passed → muted, no label; ahead-but-untimed → left plain; no bus → nothing annotated)
- [x] **Route line** verified on the canvas renderer against a local backend built from #7: route 401 traced along the real roads from Salthill through the centre out to Parkmore, stops sitting on the line
- [x] **Per-stop ETA labels** verified on the canvas renderer against prod with live data: the tracked 401's stops labelled 21:00, 21:01, 21:07, 21:08 beside their dots, tracked stop highlighted

## Not verified visually — worth knowing before merge

The Android and iOS renderers **compile but their drawing is unverified**, for environmental reasons rather than doubts about the code:

- **Android**: the emulator can't reach a local HTTP backend (no `usesCleartextTraffic` in the manifest, correctly), and prod doesn't serve shapes until #7 ships.
- **iOS**: the simulator took the local backend fine and loaded static data, but synthetic clicks don't open Compose list rows (the tab bar accepts them; list rows don't), so I couldn't navigate to a route map.

Both become straightforward once #7 is deployed — the emulator and simulator can then point at HTTPS prod and I can confirm both. I'd rather flag that than imply three renderers were checked when one was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uucVCGLGoR4gpqkxNMzT