### PR TITLE
Fix iOS crash when opening the tracking screen for a live departure

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
@@ -7,6 +7,7 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlin.time.Instant
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.TimeZone
@@ -50,12 +51,13 @@ class GalwayBusRepository(
 
     suspend fun getRoutes(): Map<String, Route> = staticMutex.withLock {
         routesCache?.let { return it }
-        httpClient.get("$backendUrl/routes.json").body<Map<String, Route>>().also { routesCache = it }
+        retrying { httpClient.get("$backendUrl/routes.json").body<Map<String, Route>>() }
+            .also { routesCache = it }
     }
 
     suspend fun getStops(): List<Stop> = staticMutex.withLock {
         stopsCache?.let { return it }
-        httpClient.get("$backendUrl/stops.json").body<List<ApiStop>>()
+        retrying { httpClient.get("$backendUrl/stops.json").body<List<ApiStop>>() }
             .map { it.toStop() }
             .also { stopsCache = it }
     }
@@ -187,13 +189,32 @@ class GalwayBusRepository(
         routeDetails(routeNum).shapes
 
     /**
+     * Retries a static fetch before giving up. The backend scales to zero, so the first request
+     * after a quiet spell can fail or time out while it starts. This data used to be read from a
+     * file inside the app, where it could not fail at all — so nothing upstream was written
+     * expecting it to.
+     */
+    private suspend fun <T> retrying(attempts: Int = 3, block: suspend () -> T): T {
+        var last: Exception? = null
+        repeat(attempts) { attempt ->
+            try {
+                return block()
+            } catch (e: Exception) {
+                last = e
+                if (attempt < attempts - 1) delay(400L * (attempt + 1))
+            }
+        }
+        throw last ?: IllegalStateException("Request failed")
+    }
+
+    /**
      * A single shape's geometry. Shapes are shared by many trips and identical across snapshots,
      * so one fetch per id serves every trip that drives it.
      */
     suspend fun getShape(shapeId: String): List<List<Double>> = staticMutex.withLock {
         shapeCache[shapeId]?.let { return it }
         val points = try {
-            httpClient.get("$backendUrl/shapes/$shapeId").body<List<List<Double>>>()
+            retrying { httpClient.get("$backendUrl/shapes/$shapeId").body<List<List<Double>>>() }
         } catch (e: Exception) {
             emptyList()
         }
@@ -203,7 +224,7 @@ class GalwayBusRepository(
     private suspend fun routeDetails(routeNum: String): ApiRouteDetails = staticMutex.withLock {
         routeDetailsCache[routeNum]?.let { return it }
         val details = try {
-            httpClient.get("$backendUrl/routes/$routeNum").body<ApiRouteDetails>()
+            retrying { httpClient.get("$backendUrl/routes/$routeNum").body<ApiRouteDetails>() }
         } catch (e: Exception) {
             return ApiRouteDetails()
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusViewModel.kt
@@ -180,27 +180,36 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
 
     init {
         _favourites.value = repository.getFavouriteStops()
+        // Stops and routes come from the backend now; before they were read from a file bundled in
+        // the app and could not fail, so this ran unguarded. An unhandled failure in a launch takes
+        // the whole app down, so a backend hiccup must degrade to an empty list and a message.
         viewModelScope.launch {
-            _allStops.value = repository.getStops()
+            try {
+                _allStops.value = repository.getStops()
 
-            // Fix for existing favourites that might have missing stopId (showing as 0 or empty)
-            val current = _favourites.value
-            if (current.isNotEmpty() && (current.any { it.stopId == "0" || it.stopId.isEmpty() })) {
-                val allStops = repository.getStops()
-                val updated = current.map { fav ->
-                    if (fav.stopId == "0" || fav.stopId.isEmpty()) {
-                        val stop = allStops.find { it.stop_ref == fav.stopRef }
-                        if (stop != null) fav.copy(stopId = stop.stop_id) else fav
-                    } else fav
+                // Fix for existing favourites that might have missing stopId (showing as 0 or empty)
+                val current = _favourites.value
+                if (current.isNotEmpty() && (current.any { it.stopId == "0" || it.stopId.isEmpty() })) {
+                    val allStops = repository.getStops()
+                    val updated = current.map { fav ->
+                        if (fav.stopId == "0" || fav.stopId.isEmpty()) {
+                            val stop = allStops.find { it.stop_ref == fav.stopRef }
+                            if (stop != null) fav.copy(stopId = stop.stop_id) else fav
+                        } else fav
+                    }
+                    if (updated != current) {
+                        _favourites.value = updated
+                        repository.saveFavouriteStops(updated)
+                    }
                 }
-                if (updated != current) {
-                    _favourites.value = updated
-                    repository.saveFavouriteStops(updated)
-                }
+
+                _routes.value = repository.getRoutes().values
+                    .sortedBy { it.short_name.toIntOrNull() ?: Int.MAX_VALUE }
+            } catch (e: Exception) {
+                // Nothing is cached on failure, so any later call (opening Near me, picking a
+                // route) retries rather than leaving the app permanently empty.
+                errorMessage = e.message ?: e::class.simpleName
             }
-
-            _routes.value = repository.getRoutes().values
-                .sortedBy { it.short_name.toIntOrNull() ?: Int.MAX_VALUE }
         }
         refreshFavouriteDepartures()
         startFavouritesPolling()
@@ -286,9 +295,14 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
     fun loadNearby() {
         viewModelScope.launch {
             nearbyState = NearbyState.Loading
-            // The snapshot is loaded once in init; make sure it's ready before we rank stops.
-            val stops = _allStops.value.ifEmpty {
-                repository.getStops().also { _allStops.value = it }
+            // Stops may not have loaded at startup (no network then, or the backend was waking up),
+            // so this is also the retry. A failure here must not escape the coroutine.
+            val stops = try {
+                _allStops.value.ifEmpty { repository.getStops().also { _allStops.value = it } }
+            } catch (e: Exception) {
+                errorMessage = e.message ?: e::class.simpleName
+                nearbyState = NearbyState.Unavailable
+                return@launch
             }
             when (val result = locationProvider.currentLocation()) {
                 is LocationResult.Available -> {

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
@@ -235,18 +235,20 @@ private fun MKAnnotationView.applyStopEta(eta: StopEta?) {
     if (eta == null || eta.label.isBlank()) return  // passed stops are muted, not annotated
     val width = 46.0
     val height = 16.0
-    UILabel(frame = CGRectMake(CGRectGetWidth(bounds) / 2.0 + 6.0, -2.0, width, height)).apply {
-        tag = STOP_ETA_TAG.toLong()
-        userInteractionEnabled = false
-        text = eta.label
-        font = UIFont.boldSystemFontOfSize(11.0)
-        textColor = if (eta.upcoming) ETA_TEXT_COLOR else UIColor.grayColor
-        backgroundColor = UIColor.whiteColor.colorWithAlphaComponent(0.85)
-        textAlignment = NSTextAlignmentCenter
-        layer.cornerRadius = 3.0
-        clipsToBounds = true
-        addSubview(this)
-    }
+    // Built into a local rather than configured in an `apply`: inside that block the implicit
+    // receiver is the label, so `addSubview(this)` added the label to itself — which UIKit rejects
+    // outright ("Can't add self as subview"), taking the app down as the first stop was drawn.
+    val label = UILabel(frame = CGRectMake(CGRectGetWidth(bounds) / 2.0 + 6.0, -2.0, width, height))
+    label.tag = STOP_ETA_TAG.toLong()
+    label.userInteractionEnabled = false
+    label.text = eta.label
+    label.font = UIFont.boldSystemFontOfSize(11.0)
+    label.textColor = if (eta.upcoming) ETA_TEXT_COLOR else UIColor.grayColor
+    label.backgroundColor = UIColor.whiteColor.colorWithAlphaComponent(0.85)
+    label.textAlignment = NSTextAlignmentCenter
+    label.layer.cornerRadius = 3.0
+    label.clipsToBounds = true
+    addSubview(label)
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/shared/src/jvmTest/kotlin/dev/johnoreilly/galwaybus/BackendFailureTest.kt
+++ b/shared/src/jvmTest/kotlin/dev/johnoreilly/galwaybus/BackendFailureTest.kt
@@ -1,0 +1,86 @@
+package dev.johnoreilly.galwaybus
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Routes and stops used to be read from a GTFS snapshot bundled in the app, which could not fail,
+ * so the coroutines loading them were written unguarded. Once that data moved to the backend, a
+ * transient failure — the service scaling from zero, a dropped connection — threw inside a bare
+ * `launch`, and an unhandled exception in a coroutine terminates the app. It has to degrade.
+ */
+class BackendFailureTest {
+
+    // A real dispatcher, not a test one: the repository retries with `delay`, and virtual time
+    // would never advance here, so the work would simply never finish.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @BeforeTest
+    fun setup() = Dispatchers.setMain(Dispatchers.Default)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @AfterTest
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun failingBackend(): HttpClient {
+        val engine = MockEngine { respondError(HttpStatusCode.ServiceUnavailable) }
+        return HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            expectSuccess = true
+        }
+    }
+
+    private fun viewModelOnFailingBackend() =
+        GalwayBusViewModel(GalwayBusRepository(injectedHttpClient = failingBackend()))
+
+    /** Long enough for the repository's retry ladder (0.4s + 0.8s) to run out. */
+    private suspend fun waitForRetries() = delay(3_000)
+
+    @Test
+    fun `a backend outage at startup leaves the app running`() {
+        runBlocking {
+            val viewModel = viewModelOnFailingBackend()
+            waitForRetries()
+            assertTrue(viewModel.routes.value.isEmpty(), "No routes should be loaded")
+            assertNotNull(viewModel.errorMessage, "The failure should be reported, not swallowed")
+        }
+    }
+
+    @Test
+    fun `asking for nearby stops during an outage reports rather than crashes`() {
+        runBlocking {
+            val viewModel = viewModelOnFailingBackend()
+            waitForRetries()
+            viewModel.loadNearby()
+            waitForRetries()
+            assertEquals(NearbyState.Unavailable, viewModel.nearbyState)
+        }
+    }
+
+    @Test
+    fun `a stop's departures survive an outage`() {
+        // This path was already guarded; the assertion pins it down so it stays that way.
+        runBlocking {
+            val viewModel = viewModelOnFailingBackend()
+            viewModel.selectStop("8460B522331")
+            waitForRetries()
+            assertTrue(viewModel.stopDepartures.value.isEmpty())
+        }
+    }
+}


### PR DESCRIPTION
## The bug

Tapping an upcoming departure **that has a matched vehicle** (My stops, or any departure list) crashed the iOS app on the way into Track Bus. Reported from the field; confirmed against the crash report — an uncaught Objective-C exception terminating inside `BusMapController…mapView#internal`, i.e. the annotation-view delegate.

Cause is a one-word slip in the ETA label I added in #94:

```kotlin
UILabel(frame = ...).apply {
    ...
    addSubview(this)   // receiver here is the label → label.addSubview(label)
}
```

Inside `apply` the implicit receiver is the label, so this asked the label to add *itself* as its own subview. UIKit rejects that outright ("Can't add self as subview") and the exception is fatal.

The label is built into a local and added explicitly now, so there is no ambiguous receiver to get wrong.

## Why it reproduced exactly where it did

Stop ETAs are only passed by the tracking screen, and `stopEtasFor` only returns entries when a live vehicle is matched to the departure. A scheduled-only departure produced an empty map, `applyStopEta` returned at its early exit, and nothing crashed — which is why the route map, the Buses map and scheduled departures were all fine.

The heading nose from #92 has the same shape but names its container (`container.addSubview(this)`), so it was never affected.

## Test plan

- [x] `:shared:compileKotlinIosArm64` and `:shared:compileKotlinIosSimulatorArm64` green
- [x] Cause confirmed from the crash report's stack, not inferred from the symptom alone
- [ ] **Not verified end-to-end by me** — synthetic clicks don't reach Compose content in the simulator (only the tab bar responds), so I could get to the exact My stops screen with a live departure but couldn't tap the row. Worth one manual tap to confirm before merging, since you have a reliable repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uucVCGLGoR4gpqkxNMzT