### PR TITLE
Make the tracking map readable on iOS

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
@@ -69,8 +69,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import kotlin.time.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.pluralStringResource
@@ -201,13 +199,28 @@ private enum class Screen {
  * has already passed: those get a muted marker and no time, since there is nothing left to wait
  * for and we have no prediction for them anyway. With no bus in the feed there is nothing to say,
  * and every stop is left plain.
+ *
+ * Only the next few stops are labelled, plus the one being tracked wherever it falls. Labelling
+ * every stop turned the map into a wall of times that collided with each other and with the map's
+ * own place names, and the far end of a trip is not what someone watching a bus is reading.
  */
-internal fun stopEtasFor(trackedBus: BusLocation?, stops: List<Stop>): Map<String, StopEta> {
+internal fun stopEtasFor(
+    trackedBus: BusLocation?,
+    stops: List<Stop>,
+    trackedStopRef: String? = null,
+    nowMs: Long = 0L,
+    labelledAhead: Int = 3
+): Map<String, StopEta> {
     val ahead = trackedBus?.next_stops.orEmpty()
-    val predicted = ahead.mapNotNull { p -> p.departure_timestamp?.let { p.stop_ref to it } }.toMap()
     val aheadRefs = ahead.map { it.stop_ref }.toSet()
+    // Ahead-list order is the order the bus reaches them, so the first few are the imminent ones.
+    val labelled = ahead.take(labelledAhead).map { it.stop_ref }.toSet() +
+        setOfNotNull(trackedStopRef?.takeIf { it in aheadRefs })
+    val predicted = ahead.mapNotNull { p -> p.departure_timestamp?.let { p.stop_ref to it } }.toMap()
     return stops.mapNotNull { stop ->
-        val label = predicted[stop.stop_ref]?.let { clockLabel(it) }
+        val label = predicted[stop.stop_ref]
+            ?.takeIf { stop.stop_ref in labelled }
+            ?.let { minutesLabel(it, nowMs) }
         when {
             label != null -> stop.stop_ref to StopEta(label, upcoming = true)
             trackedBus != null && stop.stop_ref !in aheadRefs -> stop.stop_ref to StopEta("", upcoming = false)
@@ -216,10 +229,14 @@ internal fun stopEtasFor(trackedBus: BusLocation?, stops: List<Stop>): Map<Strin
     }.toMap()
 }
 
-/** An ISO timestamp as a local clock time ("16:52"), for labelling stops on the map. */
-private fun clockLabel(isoTimestamp: String): String? = try {
-    val local = Instant.parse(isoTimestamp).toLocalDateTime(TimeZone.currentSystemDefault())
-    "${local.hour.toString().padStart(2, '0')}:${local.minute.toString().padStart(2, '0')}"
+/**
+ * Minutes until a predicted departure ("Due", "4′"), matching the timeline beside the map — which
+ * used to disagree with it, showing "2′" next to a map reading "22:27" for the same stop. Minutes
+ * are also a third the width of a clock time, so the labels stop colliding.
+ */
+private fun minutesLabel(isoTimestamp: String, nowMs: Long): String? = try {
+    val minutes = ((Instant.parse(isoTimestamp).toEpochMilliseconds() - nowMs) / 60_000).toInt()
+    if (minutes <= 0) "Due" else "$minutes′"
 } catch (e: Exception) {
     null
 }
@@ -949,7 +966,10 @@ private fun BusTrackingView(
         val directionShape = routeShapes.getOrNull(directionIndex).orEmpty()
         val tripLine = trackedShape.ifEmpty { directionShape }
 
-        val stopEtas = remember(trackedBus, timelineStops) { stopEtasFor(trackedBus, timelineStops) }
+        // Re-derived as the clock ticks so the minutes stay honest.
+        val stopEtas = remember(trackedBus, timelineStops, trackedStopRef, nowMs / 60_000) {
+            stopEtasFor(trackedBus, timelineStops, trackedStopRef, nowMs)
+        }
 
         val mapArea: @Composable (Modifier) -> Unit = { m ->
             Box(m) {

--- a/shared/src/commonTest/kotlin/dev/johnoreilly/galwaybus/StopEtaTest.kt
+++ b/shared/src/commonTest/kotlin/dev/johnoreilly/galwaybus/StopEtaTest.kt
@@ -3,6 +3,8 @@ package dev.johnoreilly.galwaybus
 import dev.johnoreilly.galwaybus.model.BusLocation
 import dev.johnoreilly.galwaybus.model.Stop
 import dev.johnoreilly.galwaybus.model.StopPrediction
+import kotlin.time.Instant
+import kotlin.time.Duration.Companion.minutes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -20,7 +22,13 @@ class StopEtaTest {
         short_name = ref, latitude = 53.27, longitude = -9.05
     )
 
-    private val stops = listOf(stop("A"), stop("B"), stop("C"), stop("D"))
+    private val stops = listOf(stop("A"), stop("B"), stop("C"), stop("D"), stop("E"), stop("F"))
+
+    private val now = Instant.parse("2026-09-06T17:00:00Z")
+    private val nowMs = now.toEpochMilliseconds()
+
+    /** An ISO timestamp [minutes] from the fixed "now" these tests run at. */
+    private fun inMinutes(minutes: Int) = (now + minutes.minutes).toString()
 
     private fun busAt(vararg ahead: Pair<String, String?>) = BusLocation(
         latitude = 53.27,
@@ -33,18 +41,41 @@ class StopEtaTest {
     )
 
     @Test
-    fun `stops ahead are labelled with their predicted time`() {
-        val etas = stopEtasFor(busAt("C" to "2026-09-06T17:05:00Z", "D" to "2026-09-06T17:12:00Z"), stops)
+    fun `stops ahead are labelled with the minutes until the bus reaches them`() {
+        // Minutes, not clock times: the timeline beside the map counts in minutes, and the two
+        // disagreeing on screen ("2′" next to "22:27" for one stop) read as two different things.
+        val etas = stopEtasFor(busAt("C" to inMinutes(5), "D" to inMinutes(12)), stops, nowMs = nowMs)
+        assertEquals("5′", etas.getValue("C").label)
+        assertEquals("12′", etas.getValue("D").label)
         assertTrue(etas.getValue("C").upcoming)
-        assertTrue(etas.getValue("D").upcoming)
-        // Formatted as a local clock time; the exact hour depends on the test machine's zone, so
-        // assert the shape rather than the value.
-        assertTrue(etas.getValue("C").label.matches(Regex("""\d{2}:\d{2}""")), "Got '${etas.getValue("C").label}'")
+    }
+
+    @Test
+    fun `a bus already there reads as Due`() {
+        val etas = stopEtasFor(busAt("C" to inMinutes(0)), stops, nowMs = nowMs)
+        assertEquals("Due", etas.getValue("C").label)
+    }
+
+    @Test
+    fun `only the next few stops are labelled`() {
+        // Labelling the whole trip filled the map with times that collided with each other and
+        // with the map's own place names.
+        val bus = busAt("A" to inMinutes(1), "B" to inMinutes(3), "C" to inMinutes(6), "D" to inMinutes(9))
+        val etas = stopEtasFor(bus, stops, nowMs = nowMs, labelledAhead = 3)
+        assertEquals(listOf("A", "B", "C"), etas.filterValues { it.label.isNotBlank() }.keys.sorted())
+        assertTrue(etas["D"] == null || etas.getValue("D").label.isBlank(), "The fourth stop ahead should be plain")
+    }
+
+    @Test
+    fun `the stop being tracked keeps its time however far ahead it is`() {
+        val bus = busAt("A" to inMinutes(1), "B" to inMinutes(3), "C" to inMinutes(6), "D" to inMinutes(20))
+        val etas = stopEtasFor(bus, stops, trackedStopRef = "D", nowMs = nowMs, labelledAhead = 2)
+        assertEquals("20′", etas.getValue("D").label, "The stop you are waiting at must always show its time")
     }
 
     @Test
     fun `stops the bus has passed are marked passed, not merely unknown`() {
-        val etas = stopEtasFor(busAt("C" to "2026-09-06T17:05:00Z", "D" to "2026-09-06T17:12:00Z"), stops)
+        val etas = stopEtasFor(busAt("C" to inMinutes(5), "D" to inMinutes(12)), stops, nowMs = nowMs)
         listOf("A", "B").forEach { ref ->
             val eta = etas[ref]
             assertTrue(eta != null, "Stop $ref should be marked as passed")
@@ -57,13 +88,13 @@ class StopEtaTest {
     fun `an upcoming stop the feed hasn't timed yet is left plain`() {
         // NTA's predictions are sparse; a stop that is ahead but untimed gets no marker treatment,
         // rather than being wrongly greyed out as passed.
-        val etas = stopEtasFor(busAt("C" to null, "D" to "2026-09-06T17:12:00Z"), stops)
+        val etas = stopEtasFor(busAt("C" to null, "D" to inMinutes(12)), stops, nowMs = nowMs)
         assertNull(etas["C"], "An ahead-but-untimed stop should not be labelled or muted")
         assertTrue(etas.getValue("D").upcoming)
     }
 
     @Test
     fun `with no bus in the feed nothing is annotated`() {
-        assertTrue(stopEtasFor(null, stops).isEmpty())
+        assertTrue(stopEtasFor(null, stops, nowMs = nowMs).isEmpty())
     }
 }

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitView
 import dev.johnoreilly.galwaybus.localizedName
@@ -36,10 +37,15 @@ import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectGetHeight
 import platform.CoreGraphics.CGRectGetWidth
 import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGLineCap
+import platform.CoreGraphics.CGLineJoin
+import platform.CoreGraphics.CGSizeMake
 import platform.CoreLocation.CLLocationCoordinate2D
 import platform.CoreLocation.CLLocationCoordinate2DMake
 import platform.MapKit.MKAnnotationView
+import platform.MapKit.MKCoordinateRegionMake
 import platform.MapKit.MKCoordinateRegionMakeWithDistance
+import platform.MapKit.MKCoordinateSpanMake
 import platform.MapKit.MKFeatureDisplayPriorityDefaultLow
 import platform.MapKit.MKFeatureDisplayPriorityRequired
 import platform.MapKit.MKFeatureVisibility
@@ -55,6 +61,9 @@ import platform.MapKit.MKPolylineRenderer
 import platform.MapKit.MKPointAnnotation
 import platform.MapKit.MKUserLocation
 import platform.UIKit.UIColor
+import platform.UIKit.UIBezierPath
+import platform.UIKit.UIGraphicsImageRenderer
+import platform.UIKit.UIImage
 import platform.UIKit.UILabel
 import platform.UIKit.UIView
 import platform.UIKit.NSTextAlignmentCenter
@@ -225,29 +234,63 @@ private class StopAnnotation(
 /** Tag identifying the ETA label subview, so a recycled annotation view drops the previous one. */
 private const val STOP_ETA_TAG = 0x8B6
 
+private var stopDotUpcoming: UIImage? = null
+private var stopDotPassed: UIImage? = null
+
+/** A stop as a small white-ringed dot, matching the weight the other renderers give it. */
+@OptIn(ExperimentalForeignApi::class)
+private fun stopDotImage(passed: Boolean): UIImage? {
+    stopDotUpcoming?.takeIf { !passed }?.let { return it }
+    stopDotPassed?.takeIf { passed }?.let { return it }
+    val size = 14.0
+    val renderer = UIGraphicsImageRenderer(size = CGSizeMake(size, size))
+    val image = renderer.imageWithActions { _ ->
+        val ring = UIBezierPath.bezierPathWithOvalInRect(CGRectMake(0.0, 0.0, size, size))
+        UIColor.whiteColor.setFill()
+        ring.fill()
+        val inner = UIBezierPath.bezierPathWithOvalInRect(CGRectMake(2.0, 2.0, size - 4.0, size - 4.0))
+        (if (passed) PASSED_STOP_COLOR else STOP_COLOR).setFill()
+        inner.fill()
+    }
+    if (passed) stopDotPassed = image else stopDotUpcoming = image
+    return image
+}
+
 /**
  * Writes a stop's predicted departure beside its pin. MapKit's own title is hidden (it renders as
  * unreadable text over the map), so the label rides as a subview instead.
  */
 @OptIn(ExperimentalForeignApi::class)
-private fun MKAnnotationView.applyStopEta(eta: StopEta?) {
+private fun MKAnnotationView.applyStopEta(eta: StopEta?, tint: UIColor) {
     viewWithTag(STOP_ETA_TAG.toLong())?.removeFromSuperview()
     if (eta == null || eta.label.isBlank()) return  // passed stops are muted, not annotated
-    val width = 46.0
-    val height = 16.0
+    val width = 36.0
+    val height = 15.0
+    // Centred under the marker rather than beside it. Hung off the right it ran off the edge of the
+    // screen for stops near it, and collided with the map's own place names.
     // Built into a local rather than configured in an `apply`: inside that block the implicit
     // receiver is the label, so `addSubview(this)` added the label to itself — which UIKit rejects
     // outright ("Can't add self as subview"), taking the app down as the first stop was drawn.
-    val label = UILabel(frame = CGRectMake(CGRectGetWidth(bounds) / 2.0 + 6.0, -2.0, width, height))
+    val label = UILabel(
+        frame = CGRectMake(
+            (CGRectGetWidth(bounds) - width) / 2.0,
+            CGRectGetHeight(bounds) + 1.0,
+            width,
+            height
+        )
+    )
     label.tag = STOP_ETA_TAG.toLong()
     label.userInteractionEnabled = false
     label.text = eta.label
     label.font = UIFont.boldSystemFontOfSize(11.0)
-    label.textColor = if (eta.upcoming) ETA_TEXT_COLOR else UIColor.grayColor
-    label.backgroundColor = UIColor.whiteColor.colorWithAlphaComponent(0.85)
+    // Tinted to the route being tracked instead of an unrelated accent colour.
+    label.textColor = if (eta.upcoming) tint else UIColor.grayColor
+    label.backgroundColor = UIColor.whiteColor.colorWithAlphaComponent(0.92)
     label.textAlignment = NSTextAlignmentCenter
     label.layer.cornerRadius = 3.0
     label.clipsToBounds = true
+    // The label hangs below the marker's own bounds, so the view must not crop its subviews.
+    clipsToBounds = false
     addSubview(label)
 }
 
@@ -258,8 +301,10 @@ private fun Color.toUIColor(): UIColor =
 private val STOP_COLOR = UIColor(red = 0.216, green = 0.278, blue = 0.310, alpha = 1.0) // #37474F
 private val TRACKED_STOP_COLOR = UIColor(red = 0.31, green = 0.0, blue = 0.0, alpha = 1.0)
 private val PASSED_STOP_COLOR = UIColor(red = 0.62, green = 0.62, blue = 0.62, alpha = 1.0)
+private val ROUTE_LINE_CASING = UIColor.whiteColor.colorWithAlphaComponent(0.9)
 private val ROUTE_LINE_COLOR = UIColor(red = 0.082, green = 0.396, blue = 0.753, alpha = 1.0)
-private val ETA_TEXT_COLOR = UIColor(red = 0.482, green = 0.121, blue = 0.635, alpha = 1.0)
+/** Fallback when the tracked route has no colour yet — the app's own dark red, not an accent. */
+private val DEFAULT_ETA_TINT = UIColor(red = 0.31, green = 0.0, blue = 0.0, alpha = 1.0)
 
 /**
  * Owns the annotations currently on the map and reconciles them against the latest data on each
@@ -274,8 +319,12 @@ private class BusMapController {
     private val busAnnotations = HashMap<String, BusAnnotation>()
     private val stopAnnotations = HashMap<String, StopAnnotation>()
     private var overlays: List<MKPolyline> = emptyList()
+    private var casings: Set<MKPolyline> = emptySet()
     private var overlayKey: String? = null
     private var stopEtas: Map<String, StopEta> = emptyMap()
+    // Times are tinted to the route being tracked, so they read as part of that line rather than
+    // as an unrelated accent.
+    private var etaTint: UIColor = DEFAULT_ETA_TINT
     private var hasCentered = false
 
     /**
@@ -288,16 +337,23 @@ private class BusMapController {
         if (key == overlayKey) return
         overlayKey = key
         overlays.forEach { mapView.removeOverlay(it) }
-        overlays = polylines.filter { it.size >= 2 }.map { line ->
+        casings = emptySet()
+        val drawn = polylines.filter { it.size >= 2 }.map { line ->
             memScoped {
                 val coords = allocArray<CLLocationCoordinate2D>(line.size)
                 line.forEachIndexed { i, p ->
                     coords[i].latitude = p.lat
                     coords[i].longitude = p.lon
                 }
-                MKPolyline.polylineWithCoordinates(coords, line.size.toULong())
+                // Two copies of the same geometry: a wide pale one underneath so the route reads
+                // over Apple's blue water and grey roads, and the coloured line on top.
+                val casing = MKPolyline.polylineWithCoordinates(coords, line.size.toULong())
+                val top = MKPolyline.polylineWithCoordinates(coords, line.size.toULong())
+                casing to top
             }
         }
+        casings = drawn.map { it.first }.toSet()
+        overlays = drawn.flatMap { listOf(it.first, it.second) }
         overlays.forEach { mapView.addOverlay(it) }
     }
 
@@ -307,6 +363,21 @@ private class BusMapController {
             viewForAnnotation: platform.MapKit.MKAnnotationProtocol
         ): MKAnnotationView? {
             if (viewForAnnotation is MKUserLocation) return null // keep the native blue dot
+
+            // An ordinary stop is a dot, not a pin. A balloon per stop buried the line and the bus
+            // under a wall of teardrops; the dot is the same weight the other renderers give it.
+            if (viewForAnnotation is StopAnnotation && !viewForAnnotation.tracked) {
+                val dotId = "stopDot"
+                val dot = mapView.dequeueReusableAnnotationViewWithIdentifier(dotId)
+                    ?: MKAnnotationView(annotation = viewForAnnotation, reuseIdentifier = dotId)
+                dot.annotation = viewForAnnotation
+                dot.image = stopDotImage(viewForAnnotation.eta?.upcoming == false)
+                dot.canShowCallout = false
+                dot.displayPriority = MKFeatureDisplayPriorityDefaultLow
+                dot.applyStopEta(viewForAnnotation.eta, etaTint)
+                return dot
+            }
+
             val reuseId = "busStopMarker"
             val view = (mapView.dequeueReusableAnnotationViewWithIdentifier(reuseId) as? MKMarkerAnnotationView)
                 ?: MKMarkerAnnotationView(annotation = viewForAnnotation, reuseIdentifier = reuseId)
@@ -321,28 +392,25 @@ private class BusMapController {
                     view.canShowCallout = false
                     view.titleVisibility = MKFeatureVisibility.MKFeatureVisibilityHidden
                     view.subtitleVisibility = MKFeatureVisibility.MKFeatureVisibilityHidden
-                    view.transform = CGAffineTransformIdentity.readValue()
+                    // Scaled up: the bus is why this screen is open, and it was smaller than the
+                    // stops it travels between.
+                    view.transform = CGAffineTransformMakeScale(1.2, 1.2)
                     view.applyHeadingNose(viewForAnnotation.busLocation.bearing, viewForAnnotation.color)
-                    view.applyStopEta(null)
+                    view.applyStopEta(null, etaTint)
                 }
+                // Only the tracked stop reaches here — every other stop is drawn as a dot above.
                 is StopAnnotation -> {
                     // Bus and stop annotations share a reuse pool, so drop any nose the recycled
                     // view was carrying from its last life as a bus.
                     view.applyHeadingNose(null, STOP_COLOR)
-                    view.markerTintColor = when {
-                        viewForAnnotation.tracked -> TRACKED_STOP_COLOR
-                        viewForAnnotation.eta?.upcoming == false -> PASSED_STOP_COLOR
-                        else -> STOP_COLOR
-                    }
+                    view.markerTintColor = TRACKED_STOP_COLOR
                     view.glyphText = null
-                    view.displayPriority = MKFeatureDisplayPriorityDefaultLow
+                    view.displayPriority = MKFeatureDisplayPriorityRequired
                     view.canShowCallout = true // stop name in the callout; tap also opens departures
                     view.titleVisibility = MKFeatureVisibility.MKFeatureVisibilityHidden
                     view.subtitleVisibility = MKFeatureVisibility.MKFeatureVisibilityHidden
-                    // Stops are secondary to buses and there are many of them, so keep the markers small.
-                    val scale = if (viewForAnnotation.tracked) 0.9 else 0.6
-                    view.transform = CGAffineTransformMakeScale(scale, scale)
-                    view.applyStopEta(viewForAnnotation.eta)
+                    view.transform = CGAffineTransformIdentity.readValue()
+                    view.applyStopEta(viewForAnnotation.eta, etaTint)
                 }
             }
             return view
@@ -350,8 +418,11 @@ private class BusMapController {
 
         override fun mapView(mapView: MKMapView, rendererForOverlay: MKOverlayProtocol): MKOverlayRenderer {
             val renderer = MKPolylineRenderer(overlay = rendererForOverlay)
-            renderer.strokeColor = ROUTE_LINE_COLOR
-            renderer.lineWidth = 4.0
+            val isCasing = casings.any { it === rendererForOverlay }
+            renderer.strokeColor = if (isCasing) ROUTE_LINE_CASING else ROUTE_LINE_COLOR
+            renderer.lineWidth = if (isCasing) 9.0 else 5.0
+            renderer.lineCap = CGLineCap.kCGLineCapRound
+            renderer.lineJoin = CGLineJoin.kCGLineJoinRound
             return renderer
         }
 
@@ -382,6 +453,13 @@ private class BusMapController {
     ) {
         syncPolylines(mapView, polylines)
         this.stopEtas = stopEtas
+        this.etaTint = positions.firstOrNull()?.timetable_id
+            ?.let { busColors[it] }
+            // Only dark route colours are readable as text on the pale label; 401's yellow all but
+            // disappeared on it, so light routes fall back to the app's own dark red.
+            ?.takeIf { it.luminance() < 0.5f }
+            ?.toUIColor()
+            ?: DEFAULT_ETA_TINT
         // Distinct headsigns per route → a stable direction index; direction 1 is glyphed "»".
         val routeHeadsigns = positions.groupBy { it.timetable_id ?: "" }
             .mapValues { (_, buses) -> buses.mapNotNull { it.headsign }.distinct().sorted() }
@@ -436,7 +514,30 @@ private class BusMapController {
             }
         }
 
-        // --- Camera: follow a tracked bus; otherwise centre once ---
+        // --- Camera: frame the wait; otherwise centre once ---
+        // When both the bus and the stop are known, show the span between them. Centring on the
+        // bus in a fixed 2km window meant the thing being waited for was often off screen, and
+        // half the map was whatever happened to be nearby — usually Galway Bay.
+        val trackedBus = trackedTripId?.let { id -> positions.find { it.trip_duid == id } }
+        val waitingAt = trackedStopRef?.let { ref -> stops.find { it.stop_ref == ref } }
+        if (trackedBus != null && waitingAt != null) {
+            val midLat = (trackedBus.latitude + waitingAt.latitude) / 2.0
+            val midLon = (trackedBus.longitude + waitingAt.longitude) / 2.0
+            // Padded so neither marker sits under the app bar or the arrival card, with a floor so
+            // a bus about to pull in doesn't zoom to street level.
+            val latSpan = maxOf(abs(trackedBus.latitude - waitingAt.latitude) * 2.2, 0.012)
+            val lonSpan = maxOf(abs(trackedBus.longitude - waitingAt.longitude) * 2.2, 0.012)
+            mapView.setRegion(
+                MKCoordinateRegionMake(
+                    CLLocationCoordinate2DMake(midLat, midLon),
+                    MKCoordinateSpanMake(latSpan, lonSpan)
+                ),
+                animated = true
+            )
+            hasCentered = true
+            return
+        }
+
         val target: Triple<Double, Double, Double>? = when {
             trackedTripId != null ->
                 positions.find { it.trip_duid == trackedTripId }


### PR DESCRIPTION
## Summary

All six suggestions from the screenshot review. The screen's problem was priority: eight balloon pins were the loudest thing on it, the bus was smaller than the stops it travels between, times ran off the right edge, and a fixed 2km window centred on the bus meant the stop being waited for was often off screen while a third of the map was Galway Bay.

1. **Stops are dots.** They were `MKMarkerAnnotationView` balloons at `scale = 0.6`; they're now small white-ringed dots drawn with `UIGraphicsImageRenderer`, the same weight the Compose renderer gives them. Only the tracked stop keeps a balloon, so "yours" reads instantly.
2. **Camera frames bus → your stop**, with padding and a minimum span so an arriving bus doesn't zoom to street level.
3. **Times moved under the marker and became relative minutes.** Hung to the right they were clipped at the screen edge and collided with Apple's place names. Minutes also match the timeline beside the map, which previously said "2′" next to a map reading "22:27" for the same stop. Only the next three stops are labelled, plus the tracked one wherever it falls.
4. **The line gained a pale casing** (same geometry added twice, wide underlay beneath the coloured stroke), so it reads over water and roads.
5. **The bus is scaled up** and outranks everything on the layer.
6. **Labels take the route's colour** rather than an unrelated purple — with a luminance guard, because 401's yellow was near-invisible on the pale label; light routes fall back to the app's dark red.

## Test plan

- [x] All targets compile: both iOS, wasm, desktop, `androidApp:assembleDebug`
- [x] `:shared:jvmTest` — 37/37, including rewritten `StopEtaTest` covering minutes rather than clock times ("5′", "Due"), the three-stop label limit, and the tracked stop keeping its time however far ahead it is
- [x] **Verified on the simulator** — route 401 tracked from Eyre Square to Salthill: dots on the line, bus and tracked stop both framed, "3′ / 4′ / 9′" under their markers, casing visible over the water
- [x] Contrast fix confirmed by re-running it: labels were washed-out yellow before the luminance guard, dark red after

Worth noting this is the first iOS map change this session I've actually been able to see, rather than reason about — the earlier crashes came from that gap.

## Not included

Apple's "Maps / Legal" attribution is still partly under the arrival card, which their guidelines want visible. That was item 7 on the list and outside what you asked for; it needs bottom map insets or a shorter card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uucVCGLGoR4gpqkxNMzT