### PR TITLE
Pick out one bus on the route map to see where it goes

### DIFF
--- a/shared/src/androidMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.android.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.android.kt
@@ -91,6 +91,7 @@ actual fun BusMapView(
     trackedTripId: String?,
     trackedStopRef: String?,
     onStopClick: ((Stop) -> Unit)?,
+    onBusClick: ((BusLocation) -> Unit)?,
     userLocation: UserLocation?,
     polylines: List<List<MapPoint>>,
     stopEtas: Map<String, StopEta>
@@ -225,7 +226,15 @@ actual fun BusMapView(
                 // a disc/square, not a pin, and the heading nose has to rotate about that point.
                 anchor = Offset(0.5f, 0.5f),
                 title = title,
-                snippet = bus.vehicle_id?.let { "Vehicle $it" }
+                snippet = bus.vehicle_id?.let { "Vehicle $it" },
+                // Above the stops: they are dense enough that a bus sitting on one was unreachable,
+                // the stop's sheet opening instead of the vehicle being selected.
+                zIndex = 2f,
+                onClick = {
+                    onBusClick?.invoke(bus)
+                    // Consume it when we handled it, so Google Maps doesn't also pop its info window.
+                    onBusClick != null
+                }
             ) {
                 BusMarkerContent(markerColor, routeLabel, dirIndex == 1, isTracked, bus.bearing)
             }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
@@ -1896,7 +1896,7 @@ private fun DetailPane(
                 }
                 val stopsOnMap = routeStops.flatten().distinctBy { it.stop_ref }
                 val busEtas = remember(selectedBus, stopsOnMap, nowMs / 60_000) {
-                    stopEtasFor(selectedBus, stopsOnMap)
+                    stopEtasFor(selectedBus, stopsOnMap, nowMs = nowMs)
                 }
 
                 BusMapView(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
@@ -195,6 +195,101 @@ private enum class Screen {
 }
 
 /**
+ * The vehicle picked out on the route map: which bus it is, and where it goes next. The map draws
+ * its whole path; this answers "when does it get to me" without having to read labels off it.
+ */
+@Composable
+private fun SelectedBusCard(
+    bus: BusLocation,
+    stops: List<Stop>,
+    nowMs: Long,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val namesByRef = remember(stops) { stops.associateBy { it.stop_ref } }
+    val upcoming = remember(bus, stops, nowMs / 60_000) {
+        bus.next_stops.orEmpty()
+            .mapNotNull { prediction ->
+                val stop = namesByRef[prediction.stop_ref] ?: return@mapNotNull null
+                val minutes = prediction.departure_timestamp?.let { ts ->
+                    runCatching {
+                        ((Instant.parse(ts).toEpochMilliseconds() - nowMs) / 60_000).toInt()
+                    }.getOrNull()
+                }
+                stop to minutes
+            }
+            .take(4)
+    }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 3.dp)
+    ) {
+        Column(Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                bus.timetable_id?.let { RouteBadge(it, large = false) }
+                Spacer(Modifier.width(8.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = bus.headsign ?: stringResource(Res.string.track_bus),
+                        style = MaterialTheme.typography.titleSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    bus.vehicle_id?.let {
+                        Text(
+                            "🚌 #$it",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Filled.Close, contentDescription = stringResource(Res.string.cd_back))
+                }
+            }
+
+            if (upcoming.isEmpty()) {
+                Text(
+                    stringResource(Res.string.not_available),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                upcoming.forEachIndexed { index, (stop, minutes) ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 3.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stop.displayName(),
+                            style = MaterialTheme.typography.bodyMedium,
+                            // The stop it reaches next is the one being waited on.
+                            fontWeight = if (index == 0) FontWeight.Bold else FontWeight.Normal,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Text(
+                            text = when {
+                                minutes == null -> "–"
+                                minutes <= 0 -> stringResource(Res.string.due)
+                                else -> stringResource(Res.string.countdown_min, minutes)
+                            },
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = if (index == 0) FontWeight.Bold else FontWeight.Normal
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
  * Predicted departure per stop for the trip being tracked, for labelling the line on the map.
  *
  * The bus only reports the stops still ahead of it, so a stop on the trip with no entry is one it
@@ -1766,18 +1861,43 @@ private fun DetailPane(
         ViewMode.MAP -> Box(modifier) {
             key(selectedRouteNum) {
                 val routeShapes by viewModel.routeShapes.collectAsStateWithLifecycle()
-                BusMapView(
-                    positions = busPositions,
-                    stops = routeStops.flatten().distinctBy { it.stop_ref },
-                    trackedTripId = viewModel.trackedTripId,
-                    trackedStopRef = viewModel.trackedStopRef,
-                    onStopClick = { viewModel.selectMapStop(it) },
-                    // Only the direction on screen, so the two lines don't overdraw each other.
-                    polylines = routeShapes.getOrNull(viewModel.selectedDirection)
+                val selectedBus = viewModel.selectedRouteBus
+                val selectedBusShape by viewModel.selectedBusShape.collectAsStateWithLifecycle()
+
+                // Tapping a bus narrows the map to that one trip: its own path (which can be a
+                // variant of the direction's) and the times it is predicting, rather than the
+                // route in general.
+                val line = when {
+                    selectedBus != null && selectedBusShape.isNotEmpty() -> listOf(selectedBusShape)
+                    else -> routeShapes.getOrNull(viewModel.selectedDirection)
                         ?.takeIf { it.isNotEmpty() }
                         ?.let { listOf(it) }
-                        .orEmpty(),
+                        .orEmpty()
+                }
+                val stopsOnMap = routeStops.flatten().distinctBy { it.stop_ref }
+                val busEtas = remember(selectedBus, stopsOnMap, nowMs / 60_000) {
+                    stopEtasFor(selectedBus, stopsOnMap)
+                }
+
+                BusMapView(
+                    positions = busPositions,
+                    stops = stopsOnMap,
+                    trackedTripId = selectedBus?.trip_duid ?: viewModel.trackedTripId,
+                    trackedStopRef = viewModel.trackedStopRef,
+                    onStopClick = { viewModel.selectMapStop(it) },
+                    onBusClick = { viewModel.selectRouteBus(it) },
+                    polylines = line,
+                    stopEtas = busEtas,
                     modifier = Modifier.fillMaxSize()
+                )
+            }
+            viewModel.selectedRouteBus?.let { bus ->
+                SelectedBusCard(
+                    bus = bus,
+                    stops = routeStops.flatten().distinctBy { it.stop_ref },
+                    nowMs = nowMs,
+                    onDismiss = { viewModel.clearRouteBusSelection() },
+                    modifier = Modifier.align(Alignment.TopCenter).padding(12.dp)
                 )
             }
             SmallFloatingActionButton(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusViewModel.kt
@@ -90,6 +90,14 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
     private val _trackedShape = MutableStateFlow<List<MapPoint>>(emptyList())
     val trackedShape: StateFlow<List<MapPoint>> = _trackedShape.asStateFlow()
 
+    // One vehicle picked out of the several running a route, so the route map can show that trip's
+    // own path and times rather than the direction's generic line.
+    var selectedRouteBus by mutableStateOf<BusLocation?>(null)
+        private set
+
+    private val _selectedBusShape = MutableStateFlow<List<MapPoint>>(emptyList())
+    val selectedBusShape: StateFlow<List<MapPoint>> = _selectedBusShape.asStateFlow()
+
     private val _directionHeadsigns = MutableStateFlow<List<String>>(emptyList())
     val directionHeadsigns: StateFlow<List<String>> = _directionHeadsigns.asStateFlow()
 
@@ -426,6 +434,26 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
 
     private var loadedTrackedShapeId: String? = null
 
+    /**
+     * Picks a bus on the route map. Tapping the same one again clears it, so the map goes back to
+     * showing the direction as a whole.
+     */
+    fun selectRouteBus(bus: BusLocation) {
+        if (selectedRouteBus?.trip_duid == bus.trip_duid) {
+            clearRouteBusSelection()
+            return
+        }
+        selectedRouteBus = bus
+        _selectedBusShape.value = emptyList()
+        val shapeId = bus.shape_id ?: return
+        launchSafely { _selectedBusShape.value = repository.getShape(shapeId).toMapPoints() }
+    }
+
+    fun clearRouteBusSelection() {
+        selectedRouteBus = null
+        _selectedBusShape.value = emptyList()
+    }
+
     fun setTrackedDeparture(departure: DepartureTime, stopRef: String) {
         trackedTripId = departure.tripId
         trackedStopRef = stopRef
@@ -447,6 +475,7 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
     }
 
     private fun selectRouteInternal(routeNum: String) {
+        clearRouteBusSelection()
         repository.saveLastViewedRoute(routeNum)
         selectedRouteNum = routeNum
         selectedDirection = 0
@@ -572,6 +601,11 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
                     "msSinceLastNonEmpty=$msSinceLastNonEmpty graceMs=$busPositionsGraceMs -> displayed=${displayed.size}"
             )
             _busPositions.value = displayed
+            // Keep the picked-out bus pointing at its latest position, so its times tick along
+            // with the feed rather than freezing at whatever they were when it was tapped.
+            selectedRouteBus?.let { selected ->
+                displayed.firstOrNull { it.trip_duid == selected.trip_duid }?.let { selectedRouteBus = it }
+            }
             if (fetched.isNotEmpty()) lastNonEmptyRouteBusesMs = now
             lastUpdatedEpochMs = now
             errorMessage = null

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.kt
@@ -110,6 +110,7 @@ internal fun OsmBusMapView(
     trackedTripId: String? = null,
     trackedStopRef: String? = null,
     onStopClick: ((Stop) -> Unit)? = null,
+    onBusClick: ((BusLocation) -> Unit)? = null,
     userLocation: UserLocation? = null,
     polylines: List<List<MapPoint>> = emptyList(),
     stopEtas: Map<String, StopEta> = emptyMap()
@@ -347,13 +348,38 @@ internal fun OsmBusMapView(
                             }
                         }
                     }
-                    .pointerInput(positions, stops, trackedStopRef, onStopClick, widthPx, heightPx) {
+                    .pointerInput(positions, stops, trackedStopRef, onStopClick, onBusClick, widthPx, heightPx) {
                         detectTapGestures(
                             onDoubleTap = { pos -> zoomAt(pos, zoom + 1) },
                             onTap = tap@{ pos ->
-                                if (onStopClick == null) return@tap
+                                if (onStopClick == null && onBusClick == null) return@tap
                                 val originXf = lonToTileXf(centerLon, zoom) - (widthPx / 2.0 / TILE_PX)
                                 val originYf = latToTileYf(centerLat, zoom) - (heightPx / 2.0 / TILE_PX)
+
+                                // Buses are tested first: they are drawn over the stops, so a tap
+                                // landing on both belongs to the bus.
+                                if (onBusClick != null) {
+                                    val busHit = positions
+                                        .map { bus ->
+                                            // Hit-test where the marker is drawn (mid-animation),
+                                            // not its final fix — they can be tens of pixels apart
+                                            // between feed updates, which is a missed tap.
+                                            val busPos = animatedPositions[bus.markerKey]
+                                                ?: LatLon(bus.latitude, bus.longitude)
+                                            val bx = ((lonToTileXf(busPos.lon, zoom) - originXf) * TILE_PX).toFloat()
+                                            val by = ((latToTileYf(busPos.lat, zoom) - originYf) * TILE_PX).toFloat()
+                                            val dx = pos.x - bx
+                                            val dy = pos.y - by
+                                            bus to (dx * dx + dy * dy)
+                                        }
+                                        .filter { (_, d2) -> d2 < 30f * 30f }
+                                        .minByOrNull { (_, d2) -> d2 }
+                                    if (busHit != null) {
+                                        onBusClick(busHit.first)
+                                        return@tap
+                                    }
+                                }
+                                if (onStopClick == null) return@tap
                                 // Nearest stop marker within touch range (generous slop for fingers)
                                 val hit = stops
                                     .filter { zoom >= STOP_MARKER_MIN_ZOOM || it.stop_ref == trackedStopRef }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/PlatformBusMapView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/PlatformBusMapView.kt
@@ -32,6 +32,8 @@ fun List<List<Double>>.toMapPoints(): List<MapPoint> =
  * @param trackedTripId when set, the map centres/highlights this bus.
  * @param trackedStopRef when set, the map centres/highlights this stop.
  * @param onStopClick invoked when a stop marker is tapped (opens its departures sheet).
+ * @param onBusClick invoked when a bus marker is tapped, for selecting one vehicle out of several
+ *   running a route. Null leaves each platform's default tap behaviour alone.
  * @param userLocation the device's location, shown as a "you are here" marker.
  * @param polylines road geometry to trace — the path a bus actually drives, rather than straight
  *   lines between its stops. Usually one line: the tracked trip's, or the shown direction's.
@@ -45,6 +47,7 @@ expect fun BusMapView(
     trackedTripId: String? = null,
     trackedStopRef: String? = null,
     onStopClick: ((Stop) -> Unit)? = null,
+    onBusClick: ((BusLocation) -> Unit)? = null,
     userLocation: UserLocation? = null,
     polylines: List<List<MapPoint>> = emptyList(),
     stopEtas: Map<String, StopEta> = emptyMap()

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
@@ -94,6 +94,7 @@ actual fun BusMapView(
     trackedTripId: String?,
     trackedStopRef: String?,
     onStopClick: ((Stop) -> Unit)?,
+    onBusClick: ((BusLocation) -> Unit)?,
     userLocation: UserLocation?,
     polylines: List<List<MapPoint>>,
     stopEtas: Map<String, StopEta>
@@ -124,7 +125,11 @@ actual fun BusMapView(
             modifier = Modifier.fillMaxSize(),
             update = { mapView ->
                 controller.onStopClick = onStopClick
-                controller.onBusClick = { bus -> selectedBusKey = bus.markerKey }
+                // With a caller handling bus taps, the selection lives there and this renderer's
+                // own info card would just duplicate it.
+                controller.onBusClick = { bus ->
+                    if (onBusClick != null) onBusClick(bus) else selectedBusKey = bus.markerKey
+                }
                 controller.onBusDeselect = { selectedBusKey = null }
                 mapView.showsUserLocation = userLocation != null
                 controller.sync(mapView, positions, stops, busColors, trackedTripId, trackedStopRef, userLocation, polylines, stopEtas)
@@ -133,7 +138,9 @@ actual fun BusMapView(
 
         // Resolve against the latest positions so the card tracks live data and disappears if the
         // bus drops out of the feed.
-        val selectedBus = selectedBusKey?.let { key -> positions.firstOrNull { it.markerKey == key } }
+        val selectedBus = selectedBusKey
+            ?.takeIf { onBusClick == null }
+            ?.let { key -> positions.firstOrNull { it.markerKey == key } }
         selectedBus?.let { bus ->
             BusInfoCard(
                 bus = bus,

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.jvm.kt
@@ -15,6 +15,7 @@ actual fun BusMapView(
     trackedTripId: String?,
     trackedStopRef: String?,
     onStopClick: ((Stop) -> Unit)?,
+    onBusClick: ((BusLocation) -> Unit)?,
     userLocation: UserLocation?,
     polylines: List<List<MapPoint>>,
     stopEtas: Map<String, StopEta>
@@ -26,6 +27,7 @@ actual fun BusMapView(
         trackedTripId = trackedTripId,
         trackedStopRef = trackedStopRef,
         onStopClick = onStopClick,
+        onBusClick = onBusClick,
         userLocation = userLocation,
         polylines = polylines,
         stopEtas = stopEtas

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.wasmJs.kt
@@ -15,6 +15,7 @@ actual fun BusMapView(
     trackedTripId: String?,
     trackedStopRef: String?,
     onStopClick: ((Stop) -> Unit)?,
+    onBusClick: ((BusLocation) -> Unit)?,
     userLocation: UserLocation?,
     polylines: List<List<MapPoint>>,
     stopEtas: Map<String, StopEta>
@@ -26,6 +27,7 @@ actual fun BusMapView(
         trackedTripId = trackedTripId,
         trackedStopRef = trackedStopRef,
         onStopClick = onStopClick,
+        onBusClick = onBusClick,
         userLocation = userLocation,
         polylines = polylines,
         stopEtas = stopEtas


### PR DESCRIPTION
## Summary

A route with seven vehicles showed seven identical markers and one generic direction line — no way to ask what any particular bus was doing. Tapping one now selects it: the map swaps in that trip's own path, and a card names the vehicle and counts down its next four stops. This is bustracker.ie's interaction, on our own data.

**No backend work needed** — `/bus.json` has carried `next_stops` and `shape_id` since the route-shapes change; the route view just wasn't feeding them to the map.

`BusMapView` gains `onBusClick`, implemented across all renderers, plus selection state in the view model that keeps the picked bus pointing at its latest position so its times tick along.

> ⚠️ Stacked on `coroutine-failure-net` (#97) — it uses `launchSafely`, so merge that first.

## Two reasons taps missed, both found by testing

- The Compose canvas hit-tested each bus at its **raw** coordinates while the marker is drawn at an **animated** position — tens of pixels apart between feed updates. The hover code already did this correctly; the tap path didn't.
- On Android the stop markers sat **above** the buses, so tapping a bus that overlapped a stop opened the stop's departures instead. Buses now carry `zIndex = 2f`.

## Test plan

- [x] All targets compile; `:shared:jvmTest` 35/35
- [x] **Verified on Android against prod**: tapped bus #1839 on route 401 → card showed "An Phairc Mhor · 🚌 #1839" with College Road **Due**, Dexcom Stadium Due, Loyola Park Due, Wellpark RC 2 min, and the map drew that trip's line
- [x] Tapped #1154 first, which showed four stops and no times — checked the feed rather than assuming a bug: five of six 401s have times for every upcoming stop, and #1154 is the one with no trip updates at all, so `enrichBus` correctly returns its stops without ETAs. The "–" fallback is doing its job

## Known issue this uncovered (pre-existing, not from this change)

**Taps do not work at all on the Compose canvas map** (desktop/web) — neither the new bus taps nor the existing `onStopClick`. I instrumented `detectTapGestures` and `onTap` never fires, even on empty map, while Compose buttons elsewhere in the same app respond to the same synthetic clicks. Reordering the gesture chain didn't help. So bus selection works on Android (and should on iOS, which routes taps through MapKit) but is dead on desktop/web until that's fixed. Worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uucVCGLGoR4gpqkxNMzT