### PR TITLE
Say the live feed is down, instead of "service may not be running"

### DIFF
--- a/shared/src/commonMain/composeResources/values-ga/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ga/strings.xml
@@ -35,6 +35,9 @@
     <string name="loading_live_buses">Busanna beo á lódáil…</string>
     <string name="no_buses_reporting">Níl aon bhus ag tuairisciú faoi láthair</string>
     <string name="service_may_not_be_running">Seans nach bhfuil an tseirbhís ag rith</string>
+    <string name="live_feed_unavailable">Níl fotha beo na mbusanna ar fáil</string>
+    <string name="live_feed_unavailable_detail">Is dócha go bhfuil na busanna ag rith — nílimid in ann teacht ar an tseirbhís rianaithe. Ag atriail.</string>
+    <string name="not_live_positions">Ní beo — na suíomhanna is déanaí a bhí ar eolas</string>
 
     <!-- Scan -->
     <string name="scan_point_camera">Dírigh do cheamara ar uimhir an stada</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -34,6 +34,9 @@
     <string name="loading_live_buses">Loading live buses…</string>
     <string name="no_buses_reporting">No buses reporting right now</string>
     <string name="service_may_not_be_running">Service may not be running</string>
+    <string name="live_feed_unavailable">Live bus feed unavailable</string>
+    <string name="live_feed_unavailable_detail">Buses are probably running — we just can\'t reach the tracking service. Retrying.</string>
+    <string name="not_live_positions">Not live — last known positions</string>
 
     <!-- Scan -->
     <string name="scan_point_camera">Point your camera at the stop\'s number</string>

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
@@ -601,6 +601,7 @@ private fun AllBusesPanel(
 ) {
     val busPositions by viewModel.allBusPositions.collectAsStateWithLifecycle()
     val allStops by viewModel.allStops.collectAsStateWithLifecycle()
+    val feedStale by viewModel.busFeedStale.collectAsStateWithLifecycle()
 
     Box(modifier) {
         BusMapView(
@@ -609,7 +610,9 @@ private fun AllBusesPanel(
             onStopClick = { viewModel.selectMapStop(it) },
             modifier = Modifier.fillMaxSize()
         )
-        viewModel.allBusesUpdatedMs?.let { updatedMs ->
+        if (feedStale) {
+            NotLiveChip(Modifier.align(Alignment.TopStart).padding(12.dp))
+        } else viewModel.allBusesUpdatedMs?.let { updatedMs ->
             Card(
                 modifier = Modifier.align(Alignment.TopStart).padding(12.dp),
                 colors = CardDefaults.cardColors(
@@ -625,8 +628,9 @@ private fun AllBusesPanel(
                 )
             }
         }
-        // Late at night the feed is legitimately empty; say so rather than
-        // leaving a silently bus-less map.
+        // An empty map has two causes and they need different words: late at night nothing is
+        // running, but during an outage the buses are out there and we just cannot see them.
+        // Telling an outage "service may not be running" is the app's most confident lie.
         if (busPositions.isEmpty()) {
             Card(
                 modifier = Modifier.align(Alignment.Center).padding(32.dp),
@@ -642,9 +646,16 @@ private fun AllBusesPanel(
                         Text(stringResource(Res.string.loading_live_buses), style = MaterialTheme.typography.bodyMedium)
                     } else {
                         Column {
-                            Text(stringResource(Res.string.no_buses_reporting), style = MaterialTheme.typography.titleSmall)
                             Text(
-                                stringResource(Res.string.service_may_not_be_running),
+                                if (feedStale) stringResource(Res.string.live_feed_unavailable)
+                                else stringResource(Res.string.no_buses_reporting),
+                                style = MaterialTheme.typography.titleSmall,
+                                color = if (feedStale) MaterialTheme.colorScheme.error
+                                        else MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                if (feedStale) stringResource(Res.string.live_feed_unavailable_detail)
+                                else stringResource(Res.string.service_may_not_be_running),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
@@ -1855,6 +1866,7 @@ private fun DetailPane(
     val directionHeadsigns by viewModel.directionHeadsigns.collectAsStateWithLifecycle()
     val stopDepartures by viewModel.stopDepartures.collectAsStateWithLifecycle()
     val favourites by viewModel.favourites.collectAsStateWithLifecycle()
+    val feedStale by viewModel.busFeedStale.collectAsStateWithLifecycle()
     val selectedRouteNum = viewModel.selectedRouteNum
 
     if (selectedRouteNum == null) {
@@ -1911,20 +1923,52 @@ private fun DetailPane(
                     modifier = Modifier.fillMaxSize()
                 )
             }
-            viewModel.selectedRouteBus?.let { bus ->
-                SelectedBusCard(
-                    bus = bus,
-                    stops = routeStops.flatten().distinctBy { it.stop_ref },
-                    nowMs = nowMs,
-                    onDismiss = { viewModel.clearRouteBusSelection() },
-                    modifier = Modifier.align(Alignment.TopCenter).padding(12.dp)
-                )
+            // Stacked rather than each aligned to its own corner: on a phone a TopStart chip and
+            // a TopCenter card overlap once the card is wide enough.
+            Column(
+                modifier = Modifier.align(Alignment.TopCenter).padding(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                if (feedStale) NotLiveChip()
+                viewModel.selectedRouteBus?.let { bus ->
+                    SelectedBusCard(
+                        bus = bus,
+                        stops = routeStops.flatten().distinctBy { it.stop_ref },
+                        nowMs = nowMs,
+                        onDismiss = { viewModel.clearRouteBusSelection() }
+                    )
+                }
             }
             SmallFloatingActionButton(
                 onClick = { viewModel.refreshPositions() },
                 modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)
             ) { Icon(Icons.Filled.Refresh, contentDescription = stringResource(Res.string.cd_refresh_positions)) }
         }
+    }
+}
+
+/**
+ * The "these markers are not live" chip, shown on a map whose positions came from the backend's
+ * last known data rather than a live fetch. Deliberately a chip and not a dialog: the buses on
+ * screen are still the best guess available, so the map stays usable and merely stops claiming
+ * to be current.
+ */
+@Composable
+private fun NotLiveChip(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.92f)
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Text(
+            stringResource(Res.string.not_live_positions),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/BusFeedUtil.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/BusFeedUtil.kt
@@ -3,25 +3,36 @@ package dev.johnoreilly.galwaybus
 import dev.johnoreilly.galwaybus.model.BusLocation
 
 /**
- * Decides which bus positions to show, smoothing over the /bus.json feed's transient empties.
+ * Decides which bus positions to show when a poll comes back empty.
  *
- * The backend intermittently returns an empty `bus` map (HTTP 200) even during active service,
- * which would otherwise blank the map every few polls. So when a poll comes back empty we keep
- * showing the last known buses until [msSinceLastNonEmpty] exceeds [graceMs] — after which a
- * sustained empty is treated as genuine "no service" and the map clears.
+ * An empty `/bus.json` has two very different meanings — "nothing is running" and "we cannot
+ * reach the live feed" — and the app used to be unable to tell them apart, so it guessed with a
+ * timer: keep the last known buses for [graceMs], then clear. That guess is wrong both ways. It
+ * hides a real outage behind markers that look live, and then clears the map with no explanation.
+ *
+ * The backend now says which it is, so the guess is only the fallback:
+ *  - Positions came back → show them. [feedStale] tells the UI whether to label them as not live;
+ *    the backend serves its own last-known data for a few minutes before giving up.
+ *  - Nothing came back and the backend says it is stale → it has given up, so we clear rather
+ *    than freezing old buses on screen forever. The UI explains why, which is the whole point.
+ *  - Nothing came back and the backend says it is fine → trust the timer as before. This is the
+ *    path for a backend too old to send the flag, where empty is still ambiguous.
  *
  * @param fetched positions from the latest poll (possibly empty).
  * @param current positions currently on the map.
  * @param msSinceLastNonEmpty time since the last non-empty poll.
- * @param graceMs how long to retain stale positions through empty polls.
+ * @param graceMs how long to retain positions through unexplained empty polls.
+ * @param feedStale whether the backend reported this response as not live.
  */
 internal fun busPositionsForDisplay(
     fetched: List<BusLocation>,
     current: List<BusLocation>,
     msSinceLastNonEmpty: Long,
-    graceMs: Long
+    graceMs: Long,
+    feedStale: Boolean = false
 ): List<BusLocation> = when {
     fetched.isNotEmpty() -> fetched
+    feedStale -> emptyList()
     current.isNotEmpty() && msSinceLastNonEmpty < graceMs -> current
     else -> emptyList()
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusRepository.kt
@@ -39,7 +39,7 @@ class GalwayBusRepository(
 
     // RT caches: epochMs timestamp paired with data
     private val vehiclesMutex = Mutex()
-    private var vehiclesCache: Pair<Long, Map<String, List<BusLocation>>>? = null
+    private var vehiclesCache: Pair<Long, BusPositions>? = null
 
     data class StopUpdate(
         val arrivalDelay: Int? = null,
@@ -85,21 +85,44 @@ class GalwayBusRepository(
 
     fun saveLastViewedRoute(routeNum: String?) = writePref(PREF_LAST_ROUTE, routeNum ?: "")
 
+    /**
+     * Live bus positions and whether the backend considers them live.
+     *
+     * [stale] is the backend saying it could not reach NTA, so these are its last known positions
+     * (or none at all). Without it an outage and an empty timetable are the same empty map, which
+     * is why the app used to guess with a timer — see [busPositionsForDisplay].
+     */
+    data class BusPositions(
+        val byRoute: Map<String, List<BusLocation>>,
+        val stale: Boolean = false
+    ) {
+        val all: List<BusLocation> get() = byRoute.values.flatten()
+        fun forRoute(routeNum: String): List<BusLocation> = byRoute[routeNum] ?: emptyList()
+    }
+
+    /** Departures for a stop, and whether their live delays are current. */
+    data class StopDepartures(
+        val times: List<DepartureTime>,
+        val stale: Boolean = false
+    )
+
     /** All Galway bus positions keyed by route number. */
-    suspend fun getBusPositions(): Map<String, List<BusLocation>> = fetchVehicles()
+    suspend fun getBusPositions(): BusPositions = fetchVehicles()
 
     /** Bus positions for a single route. Pass [forceRefresh] to bypass the cache. */
-    suspend fun getBusPositions(routeNum: String, forceRefresh: Boolean = false): List<BusLocation> =
-        fetchVehicles(forceRefresh)[routeNum] ?: emptyList()
+    suspend fun getBusPositions(routeNum: String, forceRefresh: Boolean = false): BusPositions =
+        fetchVehicles(forceRefresh)
 
     /** Get stop departures with live delay information from the GTFS-RT feed. */
-    suspend fun getStopDeparturesWithLive(stopId: String): Pair<List<DepartureTime>, Map<String, List<BusLocation>>> {
-        val livePositions = fetchVehicles()
+    suspend fun getStopDeparturesWithLive(stopId: String): StopDepartures {
+        val livePositions = fetchVehicles().byRoute
 
         val liveResponse = try {
             httpClient.get("$backendUrl/stops/$stopId").body<StopDeparturesResponse>()
         } catch (e: Exception) {
-            StopDeparturesResponse(times = emptyList())
+            // A failed request is as un-live as a stale one; say so rather than passing off an
+            // empty list as a stop with no departures due.
+            StopDeparturesResponse(times = emptyList(), stale = true)
         }
 
         val nowMs = nowEpochMilliseconds()
@@ -128,7 +151,7 @@ class GalwayBusRepository(
             if (result.size >= 5) break
         }
 
-        return result.sortedBy { it.depart_timestamp } to livePositions
+        return StopDepartures(result.sortedBy { it.depart_timestamp }, liveResponse.stale)
     }
 
     /**
@@ -233,18 +256,21 @@ class GalwayBusRepository(
 
     // ── Internal ──────────────────────────────────────────────────────────────
 
-    private suspend fun fetchVehicles(force: Boolean = false): Map<String, List<BusLocation>> = vehiclesMutex.withLock {
+    private suspend fun fetchVehicles(force: Boolean = false): BusPositions = vehiclesMutex.withLock {
         if (!force) vehiclesCache?.let { (t, data) ->
             if (nowEpochMilliseconds() - t < cacheTtlMs) {
-                println("BusFeed: cache hit age=${nowEpochMilliseconds() - t}ms routes=${data.size} buses=${data.values.sumOf { it.size }}")
+                println("BusFeed: cache hit age=${nowEpochMilliseconds() - t}ms routes=${data.byRoute.size} buses=${data.all.size} stale=${data.stale}")
                 return@withLock data
             }
         }
         val response = httpClient.get("$backendUrl/bus.json").body<BusApiResponse>()
-        val result = response.bus.mapValues { (routeId, buses) ->
-            buses.map { it.copy(timetable_id = it.timetable_id ?: routeId) }
-        }
-        println("BusFeed: network fetch force=$force routes=${result.size} buses=${result.values.sumOf { it.size }}")
+        val result = BusPositions(
+            byRoute = response.bus.mapValues { (routeId, buses) ->
+                buses.map { it.copy(timetable_id = it.timetable_id ?: routeId) }
+            },
+            stale = response.stale
+        )
+        println("BusFeed: network fetch force=$force routes=${result.byRoute.size} buses=${result.all.size} stale=${result.stale}")
         vehiclesCache = nowEpochMilliseconds() to result
         result
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/GalwayBusViewModel.kt
@@ -43,9 +43,10 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
 
     private val autoRefreshIntervalMs = 30_000L
 
-    // The /bus.json feed flaps empty for tens of seconds at a time even during active service
-    // (returns HTTP 200 with an empty `bus` map), which would otherwise blank the map every few
-    // polls. Keep showing the last known buses for this long before treating empty as "no service".
+    // Legacy safety net for an empty /bus.json the backend does not explain. The backend now
+    // reports `stale`, and holds its own last-known data behind it, so this timer only covers
+    // backends too old to send the flag — see [busPositionsForDisplay]. It can go once every
+    // deployment is new enough.
     private val busPositionsGraceMs = 120_000L
     private var lastNonEmptyBusesMs = 0L
     private var lastNonEmptyRouteBusesMs = 0L
@@ -75,6 +76,14 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
         themeMode = mode
         writePref(THEME_PREF_KEY, mode.name)
     }
+
+    /**
+     * True when the backend last told us the live feed was unreachable. Both bus maps read the
+     * same /bus.json (one cached fetch behind the repository), so one flag covers both — the UI
+     * uses it to say the feed is down rather than implying no buses are running.
+     */
+    private val _busFeedStale = MutableStateFlow(false)
+    val busFeedStale: StateFlow<Boolean> = _busFeedStale.asStateFlow()
 
     private val _busPositions = MutableStateFlow<List<BusLocation>>(emptyList())
     val busPositions: StateFlow<List<BusLocation>> = _busPositions.asStateFlow()
@@ -259,7 +268,8 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
     fun refreshAllBusPositions() {
         launchSafely {
             try {
-                val fetched = repository.getBusPositions().values.flatten()
+                val feed = repository.getBusPositions()
+                val fetched = feed.all
                 val now = nowEpochMilliseconds()
                 val previous = _allBusPositions.value
                 val msSinceLastNonEmpty = now - lastNonEmptyBusesMs
@@ -267,10 +277,12 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
                     fetched = fetched,
                     current = previous,
                     msSinceLastNonEmpty = msSinceLastNonEmpty,
-                    graceMs = busPositionsGraceMs
+                    graceMs = busPositionsGraceMs,
+                    feedStale = feed.stale
                 )
+                _busFeedStale.value = feed.stale
                 println(
-                    "BusFeed: allBuses fetched=${fetched.size} previous=${previous.size} " +
+                    "BusFeed: allBuses fetched=${fetched.size} previous=${previous.size} stale=${feed.stale} " +
                         "msSinceLastNonEmpty=$msSinceLastNonEmpty graceMs=$busPositionsGraceMs -> displayed=${displayed.size}"
                 )
                 _allBusPositions.value = displayed
@@ -279,7 +291,9 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
                     allBusesUpdatedMs = now
                 }
             } catch (e: Exception) {
-                // Network/parse failure: keep whatever we last showed rather than blanking.
+                // Network/parse failure: keep whatever we last showed rather than blanking, but
+                // stop presenting it as live — from here the map is as unreachable as a dead feed.
+                _busFeedStale.value = true
                 println("BusFeed: allBuses fetch FAILED ${e::class.simpleName}: ${e.message}")
             } finally {
                 hasLoadedAllBuses = true
@@ -302,7 +316,7 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
         launchSafely {
             isLoadingMapStop = true
             try {
-                val (departures, _) = repository.getStopDeparturesWithLive(stop.stop_ref)
+                val departures = repository.getStopDeparturesWithLive(stop.stop_ref).times
                 if (mapStop?.stop_ref == stop.stop_ref) _mapStopDepartures.value = departures
             } catch (_: Exception) {
             }
@@ -391,7 +405,7 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
         // Update each stop independently to show data as it arrives
         for (fav in favs) {
             try {
-                val (departures, _) = repository.getStopDeparturesWithLive(fav.stopRef)
+                val departures = repository.getStopDeparturesWithLive(fav.stopRef).times
                 val current = _favouriteDepartures.value.toMutableMap()
                 current[fav.stopRef] = departures
                 _favouriteDepartures.value = current
@@ -490,8 +504,10 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
                 _routeStops.value = repository.getStopsForRoute(routeNum)
                 _directionHeadsigns.value = repository.getDirectionHeadsigns(routeNum)
                 _routeShapes.value = repository.getRouteShapes(routeNum).map { it.toMapPoints() }
-                val fetched = repository.getBusPositions(routeNum)
+                val feed = repository.getBusPositions(routeNum)
+                val fetched = feed.forRoute(routeNum)
                 _busPositions.value = fetched
+                _busFeedStale.value = feed.stale
                 if (fetched.isNotEmpty()) lastNonEmptyRouteBusesMs = nowEpochMilliseconds()
                 lastUpdatedEpochMs = nowEpochMilliseconds()
             } catch (e: Exception) {
@@ -545,7 +561,7 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
     private suspend fun refreshStopDeparturesInternal(stopRef: String, showLoading: Boolean = false) {
         if (showLoading) isLoadingDepartures = true
         try {
-            val (departures, _) = repository.getStopDeparturesWithLive(stopRef)
+            val departures = repository.getStopDeparturesWithLive(stopRef).times
             // Only apply if this stop is still the selected one
             if (selectedStopRef == stopRef) _stopDepartures.value = departures
         } catch (_: Exception) {
@@ -586,7 +602,8 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
         if (isLoadingPositions || isRefreshing) return
         isRefreshing = true
         try {
-            val fetched = repository.getBusPositions(routeNum, forceRefresh = force)
+            val feed = repository.getBusPositions(routeNum, forceRefresh = force)
+            val fetched = feed.forRoute(routeNum)
             val now = nowEpochMilliseconds()
             val previous = _busPositions.value
             val msSinceLastNonEmpty = now - lastNonEmptyRouteBusesMs
@@ -594,10 +611,12 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
                 fetched = fetched,
                 current = previous,
                 msSinceLastNonEmpty = msSinceLastNonEmpty,
-                graceMs = busPositionsGraceMs
+                graceMs = busPositionsGraceMs,
+                feedStale = feed.stale
             )
+            _busFeedStale.value = feed.stale
             println(
-                "BusFeed: route=$routeNum force=$force fetched=${fetched.size} previous=${previous.size} " +
+                "BusFeed: route=$routeNum force=$force fetched=${fetched.size} previous=${previous.size} stale=${feed.stale} " +
                     "msSinceLastNonEmpty=$msSinceLastNonEmpty graceMs=$busPositionsGraceMs -> displayed=${displayed.size}"
             )
             _busPositions.value = displayed
@@ -611,6 +630,7 @@ class GalwayBusViewModel(private val repository: GalwayBusRepository) : ViewMode
             errorMessage = null
         } catch (e: Exception) {
             // Keep showing the stale list; only surface the error if there's nothing on screen
+            _busFeedStale.value = true
             println("BusFeed: route=$routeNum fetch FAILED ${e::class.simpleName}: ${e.message}")
             if (_busPositions.value.isEmpty()) {
                 errorMessage = e.message ?: e::class.simpleName

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/model/GalwayBusModels.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/model/GalwayBusModels.kt
@@ -75,11 +75,21 @@ data class StopPrediction(
 // --- Backend response wrapper ---
 
 @Serializable
-data class BusApiResponse(val bus: Map<String, List<BusLocation>>)
+data class BusApiResponse(
+    val bus: Map<String, List<BusLocation>>,
+    /**
+     * The backend could not reach NTA, so this is last-known data or nothing at all — as opposed
+     * to a genuinely quiet night, which looks identical in [bus] alone. Absent on older backends,
+     * where it defaults to false and the app behaves as it always did.
+     */
+    val stale: Boolean = false
+)
 
 @Serializable
 data class StopDeparturesResponse(
-    val times: List<DepartureTime>
+    val times: List<DepartureTime>,
+    /** See [BusApiResponse.stale] — here it means the times carry no live delay. */
+    val stale: Boolean = false
 )
 
 // --- Backend static-data payloads ---

--- a/shared/src/commonTest/kotlin/dev/johnoreilly/galwaybus/BusPositionsForDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/dev/johnoreilly/galwaybus/BusPositionsForDisplayTest.kt
@@ -38,4 +38,39 @@ class BusPositionsForDisplayTest {
     fun emptyWithNothingToRetainStaysEmpty() {
         assertTrue(busPositionsForDisplay(emptyList(), emptyList(), 0, graceMs).isEmpty())
     }
+
+    // --- once the backend says whether an empty response is an outage ---
+
+    @Test
+    fun staleFeedWithPositionsStillShowsThem() {
+        // The backend serves its own last known positions for a few minutes. They are the best
+        // guess available, so they stay on the map — the UI labels them rather than hiding them.
+        assertEquals(fetched, busPositionsForDisplay(fetched, current, 0, graceMs, feedStale = true))
+    }
+
+    @Test
+    fun staleFeedWithNothingLeftClearsImmediately() {
+        // The backend has given up, so there is nothing to smooth over. Holding the old markers
+        // for another two minutes would be showing buses no one can vouch for; the banner
+        // explains the empty map instead.
+        assertTrue(busPositionsForDisplay(emptyList(), current, 0, graceMs, feedStale = true).isEmpty())
+    }
+
+    @Test
+    fun staleFlagBeatsTheGraceTimer() {
+        // Well inside the grace window, which alone would have retained `current`.
+        assertTrue(
+            busPositionsForDisplay(emptyList(), current, 1_000, graceMs, feedStale = true).isEmpty(),
+            "An explained outage should not fall back to the timer's guess"
+        )
+    }
+
+    @Test
+    fun aHealthyEmptyStillUsesTheGraceTimer() {
+        // The old-backend path: no flag, so an empty response is still ambiguous and smoothed.
+        assertEquals(
+            current,
+            busPositionsForDisplay(emptyList(), current, 1_000, graceMs, feedStale = false)
+        )
+    }
 }

--- a/shared/src/jvmTest/kotlin/dev/johnoreilly/galwaybus/SharedLogicDesktopTest.kt
+++ b/shared/src/jvmTest/kotlin/dev/johnoreilly/galwaybus/SharedLogicDesktopTest.kt
@@ -146,7 +146,7 @@ class SharedLogicDesktopTest {
     @Test
     fun getStopDeparturesReturnsAtMost5() = kotlinx.coroutines.runBlocking {
         // The backend returns ten; the stop card shows five.
-        val (departures, _) = repository.getStopDeparturesWithLive("8460B522331")
+        val departures = repository.getStopDeparturesWithLive("8460B522331").times
         assertTrue(departures.size <= 5, "Expected at most 5 departures, but got ${departures.size}")
         assertTrue(departures.isNotEmpty(), "Expected the backend's departures to come through")
     }

--- a/shared/src/jvmTest/kotlin/dev/johnoreilly/galwaybus/StaleFeedTest.kt
+++ b/shared/src/jvmTest/kotlin/dev/johnoreilly/galwaybus/StaleFeedTest.kt
@@ -1,0 +1,76 @@
+package dev.johnoreilly.galwaybus
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The backend can now distinguish "no buses are running" from "we cannot reach NTA", and says so
+ * with `stale`. These check the flag survives the wire into the repository, and — importantly —
+ * that a backend which has never heard of the field still behaves exactly as it used to.
+ */
+class StaleFeedTest {
+
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    private fun repository(body: String) = GalwayBusRepository(
+        HttpClient(MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            expectSuccess = true
+        }
+    )
+
+    private val oneBus = """
+        {"latitude":53.27,"longitude":-9.05,"modified_timestamp":"","trip_duid":"T1","timetable_id":"401"}
+    """.trimIndent()
+
+    @Test
+    fun `a stale bus feed is reported as stale`() = runBlocking {
+        val feed = repository("""{"bus":{"401":[$oneBus]},"stale":true}""").getBusPositions()
+        assertTrue(feed.stale, "The backend said this was not live data")
+        assertEquals(1, feed.all.size, "Stale positions are still the best guess available, so they come through")
+    }
+
+    @Test
+    fun `a live bus feed is not stale`() = runBlocking {
+        val feed = repository("""{"bus":{"401":[$oneBus]},"stale":false}""").getBusPositions()
+        assertFalse(feed.stale)
+        assertEquals(1, feed.all.size)
+    }
+
+    @Test
+    fun `an older backend that omits the flag is treated as live`() = runBlocking {
+        // The field is absent from every response the deployed backend sends today. Defaulting it
+        // to false is what keeps this change safe to ship before the backend is redeployed.
+        val feed = repository("""{"bus":{"401":[$oneBus]}}""").getBusPositions()
+        assertFalse(feed.stale, "A missing flag must not read as an outage")
+        assertEquals(1, feed.all.size)
+    }
+
+    @Test
+    fun `an empty stale feed still carries the flag`() = runBlocking {
+        val feed = repository("""{"bus":{},"stale":true}""").getBusPositions()
+        assertTrue(feed.stale, "An outage with nothing to show is exactly the case the banner exists for")
+        assertTrue(feed.all.isEmpty())
+    }
+
+    @Test
+    fun `forRoute picks one route out of the feed`() = runBlocking {
+        val feed = repository("""{"bus":{"401":[$oneBus]},"stale":true}""").getBusPositions("401")
+        assertEquals(1, feed.forRoute("401").size)
+        assertTrue(feed.forRoute("409").isEmpty())
+        assertTrue(feed.stale, "Staleness is a property of the feed, not of the route asked for")
+    }
+}


### PR DESCRIPTION
Depends on **GalwayBusBackend#8**, which adds the `stale` flag this reads. Safe to merge and ship before that is deployed — the flag defaults to false, so against today’s backend the app behaves exactly as it does now.

## The problem

An empty `/bus.json` meant two different things — "nothing is running" and "we cannot reach the live feed" — and the app could not tell them apart. So it guessed with a timer (`busPositionsGraceMs = 120_000`): keep the last known buses for two minutes, then clear.

That guess is wrong in both directions:

- During an outage it holds markers that look live and current.
- Then it empties the map under a card reading **"No buses reporting right now / Service may not be running"** — which is flatly untrue during an outage. The buses are out there; we just cannot see them.

## Summary

- Read `stale` from `/bus.json` and `/stops/{ref}.json`, exposed as `GalwayBusViewModel.busFeedStale`.
- **Stale positions still show** — they are the best guess available — but the map labels them `Not live — last known positions` instead of dating them "Updated 20s ago", which would vouch for buses that may have moved.
- **When the backend has given up** (stale with nothing left), clear immediately rather than freezing old buses on screen, and say the feed is unreachable and retrying.
- **A network failure on our side sets the flag too.** From the user’s seat, an unreachable backend and a dead feed are the same thing.
- The two-minute timer **stays** as the fallback for backends too old to send the flag. It can be deleted once every deployment is new enough — noted in the code.
- Drops the vehicle map `getStopDeparturesWithLive` returned alongside its departures: every caller discarded it.

Irish strings added alongside the English ones — **these are my translations and want a native check** before release.

## Test plan

- [x] `./gradlew :shared:jvmTest` — 47 tests, all green (9 new)
- [x] `BusPositionsForDisplayTest` (4 new): stale-with-positions still shows them; stale-with-nothing clears immediately; the flag beats the grace timer; a healthy empty still uses the timer (the old-backend path)
- [x] `StaleFeedTest` (5 new): the flag survives the wire in both states; **a backend omitting it is treated as live**; an empty stale feed still carries the flag; `forRoute` filters positions without losing staleness
- [x] Compiles on all five targets: Android, iOS simulator (arm64), desktop/JVM, wasmJs, shared
- [x] **Ran against the production backend** — parses today’s responses correctly (`routes=6 buses=33 stale=false`), confirming the backward-compatible default
- [x] **Visually verified on desktop** with the flag forced on: chip renders on the all-buses map and the route map, clears the "Updated" card rather than sitting beside it, and does not collide with the route legend
- [ ] Not verified on iOS — no XCUITest for these screens, and sim clicks only reach the tab bar

## Note on layout

The chip and `SelectedBusCard` are stacked in one `TopCenter` column rather than aligned to separate corners: on a phone a `TopStart` chip and a `TopCenter` card overlap once the card is wide enough. Verified on desktop; the phone-width case is reasoned, not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uucVCGLGoR4gpqkxNMzT