### PR TITLE
Make the MCP server build again

### DIFF
--- a/mcp-server/build.gradle.kts
+++ b/mcp-server/build.gradle.kts
@@ -24,6 +24,13 @@ application {
     mainClass = "MainKt"
 }
 
+// The shared module pulls the same lifecycle-runtime-compose jar in under two coordinates, which
+// the `application` plugin's distTar/distZip refuse to package without being told what to do.
+// Only the archive tasks need this; shadowJar does its own merging.
+tasks.withType<AbstractArchiveTask>().configureEach {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 tasks.shadowJar {
     archiveFileName.set("serverAll.jar")
     archiveClassifier.set("")

--- a/mcp-server/src/main/kotlin/server.kt
+++ b/mcp-server/src/main/kotlin/server.kt
@@ -74,7 +74,7 @@ fun configureServer(): Server {
         val stopId = request.arg("stopId") ?: return@addTool missing("stopId")
         toolResult("getting bus departures") {
             val stopRef = resolveStopRef(stopId) ?: return@toolResult listOf("No stop found with id \"$stopId\".")
-            val departures = repository.getStopDepartures(stopRef)
+            val departures = repository.getStopDeparturesWithLive(stopRef).times
             if (departures.isEmpty()) listOf("No upcoming departures for stop $stopId.")
             else departures.map { "${it.timetable_id} → ${it.display_name} at ${it.depart_timestamp ?: "scheduled"}" }
         }
@@ -107,9 +107,9 @@ fun configureServer(): Server {
         val routeId = request.arg("routeId")
         toolResult("getting live buses") {
             val buses = if (routeId != null) {
-                repository.getBusPositions(routeId).map { routeId to it }
+                repository.getBusPositions(routeId).forRoute(routeId).map { routeId to it }
             } else {
-                repository.getBusPositions().flatMap { (route, list) -> list.map { route to it } }
+                repository.getBusPositions().byRoute.flatMap { (route, list) -> list.map { route to it } }
             }
             if (buses.isEmpty()) {
                 listOf(if (routeId != null) "No live buses for route $routeId." else "No live buses right now.")
@@ -146,12 +146,18 @@ fun configureServer(): Server {
         val stopId = request.arg("stopId") ?: return@addTool missing("stopId")
         toolResult("getting live departures") {
             val stopRef = resolveStopRef(stopId) ?: return@toolResult listOf("No stop found with id \"$stopId\".")
-            val departures = repository.getStopDeparturesWithLive(stopRef).first
+            val result = repository.getStopDeparturesWithLive(stopRef)
+            val departures = result.times
             if (departures.isEmpty()) listOf("No upcoming departures for stop $stopId.")
-            else departures.map {
-                val live = if (it.vehicleId != null) " [live]" else ""
-                val delay = it.delaySeconds?.let(::delayLabel) ?: ""
-                "${it.timetable_id} → ${it.display_name} at ${it.depart_timestamp ?: "scheduled"}$live$delay"
+            else {
+                // The backend flags a response it could not refresh from the live feed. This tool
+                // is the "with live" one, so saying nothing would pass stale times off as current.
+                val header = if (result.stale) listOf("(live feed unavailable — times below are not current)") else emptyList()
+                header + departures.map {
+                    val live = if (it.vehicleId != null) " [live]" else ""
+                    val delay = it.delaySeconds?.let(::delayLabel) ?: ""
+                    "${it.timetable_id} → ${it.display_name} at ${it.depart_timestamp ?: "scheduled"}$live$delay"
+                }
             }
         }
     }


### PR DESCRIPTION
Found while verifying the Renovate bumps compiled on every module. `:mcp-server` is in **no CI workflow**, so it had drifted out of sync with the repository API and nothing caught it.

## Three separate breakages

1. **`getStopDepartures` has not existed on `GalwayBusRepository` for some time** — the live-aware call is `getStopDeparturesWithLive`. Pre-existing, unrelated to recent work.
2. **`getBusPositions` returns `BusPositions` rather than a bare map** since #100, so call sites need `.forRoute()` / `.byRoute`, and `getStopDeparturesWithLive` returns a named type rather than a `Pair`. That part is fallout from #100 — which CI passed precisely because it never builds this module.
3. **`distTar`/`distZip` refused to package a duplicate lifecycle jar**, so even a compiling module failed `build`. Pre-existing.

## Also

`get-departures-with-live` now says when the backend could not refresh from the live feed. It is the "with live" tool; passing stale times off as current is exactly what the `stale` flag exists to prevent.

## Test plan

- [x] `./gradlew :mcp-server:build` — **succeeds**, which it did not before this change on any recent commit
- [x] Confirmed breakage 1 and 3 pre-date #100 by building the module at `48e1220` (the commit before #100 merged)
- [x] Rest of the project still builds: shared/jvmTest 47 green, Android, desktop, wasmJs, iOS arm64 + simulator

## Worth deciding separately

Nothing builds this module in CI, which is how it rotted. Adding `:mcp-server:build` to the Android workflow would stop it happening again — not done here to keep this PR to the repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uucVCGLGoR4gpqkxNMzT