### PR TITLE
Show the bus when the tracking screen opens, not a poll later

### DIFF
--- a/shared/src/androidMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.android.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.android.kt
@@ -116,11 +116,22 @@ actual fun BusMapView(
     // fit every stop into view instead of a fixed zoom — a fixed zoom level covers wildly
     // different geographic spans depending on the device's screen size/aspect ratio.
     var hasCentered by remember { mutableStateOf(false) }
-    LaunchedEffect(positions, trackedTripId, trackedStopRef, userLocation) {
+    // The camera cannot be driven until the map is attached. Animating before that is silently
+    // dropped — not an error, just nothing — and because `positions` only changes content every
+    // 30s poll, the effect below would not re-run to try again. That single lost call is why the
+    // tracking screen opened on the default city view with the bus off-screen, then righted
+    // itself a poll or two later. Keying on this re-runs the effect the moment the map is ready.
+    var mapLoaded by remember { mutableStateOf(false) }
+    // Resolved first so a tracked trip whose bus is not in the feed *yet* falls through to the
+    // branches below. Testing `trackedTripId != null` directly would match this branch, find no
+    // bus, and leave the camera parked on the default city view — which is what the tracking
+    // screen used to open as: no bus, and not even the user's own stop in frame, until a later
+    // poll happened to land.
+    val trackedBus = trackedTripId?.let { id -> positions.find { it.trip_duid == id } }
+    LaunchedEffect(mapLoaded, positions, trackedTripId, trackedStopRef, userLocation) {
+        if (!mapLoaded) return@LaunchedEffect
         val target: Pair<LatLng, Float>? = when {
-            trackedTripId != null ->
-                positions.find { it.trip_duid == trackedTripId }
-                    ?.let { LatLng(it.latitude, it.longitude) to 16f }
+            trackedBus != null -> LatLng(trackedBus.latitude, trackedBus.longitude) to 16f
             userLocation != null && !hasCentered ->
                 LatLng(userLocation.lat, userLocation.lon) to 15f
             trackedStopRef != null && !hasCentered ->
@@ -129,8 +140,15 @@ actual fun BusMapView(
             else -> null
         }
         target?.let { (latLng, zoom) ->
-            hasCentered = true
-            cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(latLng, zoom))
+            // Mark as centred only once the move actually lands. Animating before the map has been
+            // laid out throws, and marking first would record a move that never happened, leaving
+            // the "centre once" branches above permanently satisfied.
+            try {
+                cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(latLng, zoom))
+                hasCentered = true
+            } catch (_: IllegalStateException) {
+                // Map not ready; the next positions poll re-runs this effect.
+            }
         }
     }
 
@@ -139,6 +157,7 @@ actual fun BusMapView(
     GoogleMap(
         modifier = modifier,
         cameraPositionState = cameraPositionState,
+        onMapLoaded = { mapLoaded = true },
         properties = MapProperties(
             mapStyleOptions = if (dark) MapStyleOptions(DARK_MAP_STYLE_JSON) else null
         ),

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.kt
@@ -152,13 +152,15 @@ internal fun OsmBusMapView(
     }
 
     LaunchedEffect(positions, trackedTripId, trackedStopRef, userLocation) {
-        if (trackedTripId != null) {
-            positions.find { it.trip_duid == trackedTripId }?.let { bus ->
-                centerLat = bus.latitude
-                centerLon = bus.longitude
-                zoom = MAX_ZOOM - 1
-                hasCentered = true
-            }
+        // Note the `trackedBus != null` rather than `trackedTripId != null`: a tracked trip whose
+        // bus has not reached the feed yet must fall through to the branches below, or the camera
+        // stays on the default city view showing neither the bus nor the user's own stop.
+        val trackedBus = trackedTripId?.let { id -> positions.find { it.trip_duid == id } }
+        if (trackedBus != null) {
+            centerLat = trackedBus.latitude
+            centerLon = trackedBus.longitude
+            zoom = MAX_ZOOM - 1
+            hasCentered = true
         } else if (userLocation != null && !hasCentered) {
             centerLat = userLocation.lat
             centerLon = userLocation.lon

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/galwaybus/map/BusMapView.ios.kt
@@ -545,10 +545,11 @@ private class BusMapController {
             return
         }
 
+        // Resolved up front so a tracked trip with no bus in the feed yet falls through to the
+        // stop below, instead of matching here and yielding no target at all.
+        val followBus = trackedTripId?.let { id -> positions.find { it.trip_duid == id } }
         val target: Triple<Double, Double, Double>? = when {
-            trackedTripId != null ->
-                positions.find { it.trip_duid == trackedTripId }
-                    ?.let { Triple(it.latitude, it.longitude, 2000.0) }
+            followBus != null -> Triple(followBus.latitude, followBus.longitude, 2000.0)
             userLocation != null && !hasCentered ->
                 Triple(userLocation.lat, userLocation.lon, 3000.0)
             trackedStopRef != null && !hasCentered ->


### PR DESCRIPTION
Opening **Track Bus** from a saved stop left the map on the default Galway city view — no bus marker, and not even the tapped stop in frame. It righted itself a poll or two later, which made it look like the bus was missing entirely.

Reproduced on an emulator (Ladies Beach → next departure), then instrumented to find the cause rather than guess.

## Two causes, both in the camera logic

**1. The camera move was made before the map existed, and never retried.**

`cameraPositionState.animate` cannot drive the map until it is attached; called earlier the move is silently dropped — not an error, just nothing. Logging showed the centring effect ran **exactly once**, at open, with a perfectly good target:

```
CAM: effect run positions=1 trackedTripId=5879_79550 trackedBus=5879_79550 stops=38 hasCentered=false
CAM: target=(lat/lng: (53.2644196,-9.08317), 16.0)
```

…and the camera never moved. Because the effect keys on `positions`, whose *content* only changes on the 30s poll, it never ran again to retry. Now keyed on `onMapLoaded`, so it re-runs the moment the map is ready.

**2. The tracked-trip branch swallowed its own fallbacks.**

`trackedTripId != null ->` matched whenever a trip was being tracked, then produced no target if that trip’s bus was not in the feed yet — so the `when` never reached the "centre on the tracked stop" branch below it. A departure whose bus has not started its trip framed *nothing*. Resolving the bus first lets it fall through.

That second shape was in **all three renderers**, so the Compose-canvas and MapKit ones are fixed too. Only Google Maps needs the readiness gate — the other two drive the camera through state they own.

## Test plan

- [x] **Verified on an emulator**: before, the map sat on the city view with the bus off-screen; after, at 5 s it is centred on the bus at zoom 16 with the route line, timeline ("Pearse Stadium — Next stop") and "Arriving at Ladies Beach — 9 min"
- [x] `./gradlew :shared:jvmTest` — 47 tests, 0 failures
- [x] Compiles on Android, desktop/JVM, wasmJs, iOS arm64 + simulator, and `:mcp-server`
- [x] Temporary instrumentation removed (`grep -rn "CAM:" shared/src` is clean)
- [ ] Desktop and iOS fixes are **reasoned, not exercised** — the canvas map has no working taps, and there is still no XCUITest for the tracking screen

## Note

Worth knowing separately: at the time of testing, none of Ladies Beach’s upcoming departures had a live vehicle at all (departures were trips `5879_79550+`, while the six live 401 buses were on `79478`–`79532`). That is normal — those buses have not started their trips — and is exactly the case cause 2 handles, since the map should still frame your stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uucVCGLGoR4gpqkxNMzT