### PR TITLE
Put clock times back on the map, and on the timeline beside it

### DIFF
--- a/shared/src/commonMain/composeResources/values-ga/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ga/strings.xml
@@ -69,8 +69,6 @@
     <string name="not_available">N/A</string>
     <string name="countdown_min">%1$d nóim</string>
     <string name="countdown_hours_min">%1$du %2$dnóim</string>
-    <string name="gutter_min">%1$d′</string>
-    <string name="gutter_hours_min">%1$du %2$d′</string>
     <string name="late_suffix"> (déanach)</string>
     <string name="early_suffix"> (luath)</string>
     <string name="min_late">%1$d nóim déanach</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -65,8 +65,6 @@
     <string name="not_available">N/A</string>
     <string name="countdown_min">%1$d min</string>
     <string name="countdown_hours_min">%1$dh %2$dmin</string>
-    <string name="gutter_min">%1$d′</string>
-    <string name="gutter_hours_min">%1$dh %2$d′</string>
     <string name="late_suffix"> (late)</string>
     <string name="early_suffix"> (early)</string>
     <string name="min_late">%1$d min late</string>

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/galwaybus/App.kt
@@ -69,6 +69,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 import kotlin.time.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.pluralStringResource
@@ -303,8 +305,9 @@ internal fun stopEtasFor(
     trackedBus: BusLocation?,
     stops: List<Stop>,
     trackedStopRef: String? = null,
-    nowMs: Long = 0L,
-    labelledAhead: Int = 3
+    labelledAhead: Int = 3,
+    /** Injectable so the rendered clock string can be asserted without depending on the host's zone. */
+    zone: TimeZone = TimeZone.currentSystemDefault()
 ): Map<String, StopEta> {
     val ahead = trackedBus?.next_stops.orEmpty()
     val aheadRefs = ahead.map { it.stop_ref }.toSet()
@@ -315,7 +318,7 @@ internal fun stopEtasFor(
     return stops.mapNotNull { stop ->
         val label = predicted[stop.stop_ref]
             ?.takeIf { stop.stop_ref in labelled }
-            ?.let { minutesLabel(it, nowMs) }
+            ?.let { clockLabel(it, zone) }
         when {
             label != null -> stop.stop_ref to StopEta(label, upcoming = true)
             trackedBus != null && stop.stop_ref !in aheadRefs -> stop.stop_ref to StopEta("", upcoming = false)
@@ -325,13 +328,15 @@ internal fun stopEtasFor(
 }
 
 /**
- * Minutes until a predicted departure ("Due", "4′"), matching the timeline beside the map — which
- * used to disagree with it, showing "2′" next to a map reading "22:27" for the same stop. Minutes
- * are also a third the width of a clock time, so the labels stop colliding.
+ * An ISO timestamp as a local clock time ("16:52"), for the predicted departure at a stop.
+ *
+ * Shared by the map labels and the timeline gutter so the two cannot drift apart again: they once
+ * disagreed about the same stop, one reading "2′" and the other "22:27". A clock time is also what
+ * you compare against a printed timetable, which a countdown is not.
  */
-private fun minutesLabel(isoTimestamp: String, nowMs: Long): String? = try {
-    val minutes = ((Instant.parse(isoTimestamp).toEpochMilliseconds() - nowMs) / 60_000).toInt()
-    if (minutes <= 0) "Due" else "$minutes′"
+private fun clockLabel(isoTimestamp: String, zone: TimeZone = TimeZone.currentSystemDefault()): String? = try {
+    val local = Instant.parse(isoTimestamp).toLocalDateTime(zone)
+    "${local.hour.toString().padStart(2, '0')}:${local.minute.toString().padStart(2, '0')}"
 } catch (e: Exception) {
     null
 }
@@ -1073,8 +1078,8 @@ private fun BusTrackingView(
         val tripLine = trackedShape.ifEmpty { directionShape }
 
         // Re-derived as the clock ticks so the minutes stay honest.
-        val stopEtas = remember(trackedBus, timelineStops, trackedStopRef, nowMs / 60_000) {
-            stopEtasFor(trackedBus, timelineStops, trackedStopRef, nowMs)
+        val stopEtas = remember(trackedBus, timelineStops, trackedStopRef) {
+            stopEtasFor(trackedBus, timelineStops, trackedStopRef)
         }
 
         val mapArea: @Composable (Modifier) -> Unit = { m ->
@@ -1104,7 +1109,6 @@ private fun BusTrackingView(
                 stops = timelineStops,
                 targetStopRef = trackedStopRef,
                 trackedBus = displayPositions.firstOrNull(),
-                nowMs = nowMs,
                 modifier = m
             )
         }
@@ -1143,7 +1147,6 @@ private fun RouteTimeline(
     stops: List<Stop>,
     targetStopRef: String?,
     trackedBus: BusLocation?,
-    nowMs: Long,
     modifier: Modifier = Modifier
 ) {
     // Where the bus is along the route, for the passed/next markers. Prefers the real-time
@@ -1193,14 +1196,7 @@ private fun RouteTimeline(
 
         // Predicted arrival for this stop ("Due" / "3 min" / "1h 9min"), if the live
         // next_stops payload covers it. Shown in the left gutter for stops still ahead.
-        val etaText = etaByStopRef[stop.stop_ref]?.let { ts ->
-            val mins = ((Instant.parse(ts).toEpochMilliseconds() - nowMs) / 1000 / 60).toInt()
-            when {
-                mins <= 0 -> stringResource(Res.string.due)
-                mins < 60 -> stringResource(Res.string.gutter_min, mins)
-                else -> stringResource(Res.string.gutter_hours_min, mins / 60, mins % 60)
-            }
-        }
+        val etaText = etaByStopRef[stop.stop_ref]?.let { clockLabel(it) }
 
         JetLimeExtendedEvent(
             style = JetLimeEventDefaults.eventStyle(
@@ -1223,7 +1219,7 @@ private fun RouteTimeline(
             ),
             additionalContentMaxWidth = 52.dp,
             additionalContent = {
-                // Minutes-to-arrival, right-aligned against the line. Only for stops the
+                // Predicted departure time, right-aligned against the line. Only for stops the
                 // bus hasn't reached yet; passed stops leave the gutter blank. The box is
                 // always the full width so every node lines up regardless of gutter text.
                 Box(
@@ -1907,8 +1903,8 @@ private fun DetailPane(
                         .orEmpty()
                 }
                 val stopsOnMap = routeStops.flatten().distinctBy { it.stop_ref }
-                val busEtas = remember(selectedBus, stopsOnMap, nowMs / 60_000) {
-                    stopEtasFor(selectedBus, stopsOnMap, nowMs = nowMs)
+                val busEtas = remember(selectedBus, stopsOnMap) {
+                    stopEtasFor(selectedBus, stopsOnMap)
                 }
 
                 BusMapView(

--- a/shared/src/commonTest/kotlin/dev/johnoreilly/galwaybus/StopEtaTest.kt
+++ b/shared/src/commonTest/kotlin/dev/johnoreilly/galwaybus/StopEtaTest.kt
@@ -4,6 +4,7 @@ import dev.johnoreilly.galwaybus.model.BusLocation
 import dev.johnoreilly.galwaybus.model.Stop
 import dev.johnoreilly.galwaybus.model.StopPrediction
 import kotlin.time.Instant
+import kotlinx.datetime.TimeZone
 import kotlin.time.Duration.Companion.minutes
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,7 +26,8 @@ class StopEtaTest {
     private val stops = listOf(stop("A"), stop("B"), stop("C"), stop("D"), stop("E"), stop("F"))
 
     private val now = Instant.parse("2026-09-06T17:00:00Z")
-    private val nowMs = now.toEpochMilliseconds()
+    /** Pinned: clock labels are rendered in a zone, and CI runs in UTC while a dev Mac does not. */
+    private val zone = TimeZone.UTC
 
     /** An ISO timestamp [minutes] from the fixed "now" these tests run at. */
     private fun inMinutes(minutes: Int) = (now + minutes.minutes).toString()
@@ -41,19 +43,25 @@ class StopEtaTest {
     )
 
     @Test
-    fun `stops ahead are labelled with the minutes until the bus reaches them`() {
-        // Minutes, not clock times: the timeline beside the map counts in minutes, and the two
-        // disagreeing on screen ("2′" next to "22:27" for one stop) read as two different things.
-        val etas = stopEtasFor(busAt("C" to inMinutes(5), "D" to inMinutes(12)), stops, nowMs = nowMs)
-        assertEquals("5′", etas.getValue("C").label)
-        assertEquals("12′", etas.getValue("D").label)
+    fun `stops ahead are labelled with the predicted clock time`() {
+        // Clock times, not a countdown: this is the number you compare against a printed
+        // timetable, and the timeline gutter beside the map renders the same string.
+        val etas = stopEtasFor(busAt("C" to inMinutes(5), "D" to inMinutes(12)), stops, zone = zone)
+        assertEquals("17:05", etas.getValue("C").label)
+        assertEquals("17:12", etas.getValue("D").label)
         assertTrue(etas.getValue("C").upcoming)
     }
 
     @Test
-    fun `a bus already there reads as Due`() {
-        val etas = stopEtasFor(busAt("C" to inMinutes(0)), stops, nowMs = nowMs)
-        assertEquals("Due", etas.getValue("C").label)
+    fun `an imminent stop still shows its time`() {
+        val etas = stopEtasFor(busAt("C" to inMinutes(0)), stops, zone = zone)
+        assertEquals("17:00", etas.getValue("C").label)
+    }
+
+    @Test
+    fun `the clock label rolls over the hour correctly`() {
+        val etas = stopEtasFor(busAt("C" to inMinutes(65)), stops, zone = zone)
+        assertEquals("18:05", etas.getValue("C").label, "17:00 + 65 min is 18:05, not 17:65")
     }
 
     @Test
@@ -61,7 +69,7 @@ class StopEtaTest {
         // Labelling the whole trip filled the map with times that collided with each other and
         // with the map's own place names.
         val bus = busAt("A" to inMinutes(1), "B" to inMinutes(3), "C" to inMinutes(6), "D" to inMinutes(9))
-        val etas = stopEtasFor(bus, stops, nowMs = nowMs, labelledAhead = 3)
+        val etas = stopEtasFor(bus, stops, labelledAhead = 3, zone = zone)
         assertEquals(listOf("A", "B", "C"), etas.filterValues { it.label.isNotBlank() }.keys.sorted())
         assertTrue(etas["D"] == null || etas.getValue("D").label.isBlank(), "The fourth stop ahead should be plain")
     }
@@ -69,13 +77,13 @@ class StopEtaTest {
     @Test
     fun `the stop being tracked keeps its time however far ahead it is`() {
         val bus = busAt("A" to inMinutes(1), "B" to inMinutes(3), "C" to inMinutes(6), "D" to inMinutes(20))
-        val etas = stopEtasFor(bus, stops, trackedStopRef = "D", nowMs = nowMs, labelledAhead = 2)
-        assertEquals("20′", etas.getValue("D").label, "The stop you are waiting at must always show its time")
+        val etas = stopEtasFor(bus, stops, trackedStopRef = "D", labelledAhead = 2, zone = zone)
+        assertEquals("17:20", etas.getValue("D").label, "The stop you are waiting at must always show its time")
     }
 
     @Test
     fun `stops the bus has passed are marked passed, not merely unknown`() {
-        val etas = stopEtasFor(busAt("C" to inMinutes(5), "D" to inMinutes(12)), stops, nowMs = nowMs)
+        val etas = stopEtasFor(busAt("C" to inMinutes(5), "D" to inMinutes(12)), stops, zone = zone)
         listOf("A", "B").forEach { ref ->
             val eta = etas[ref]
             assertTrue(eta != null, "Stop $ref should be marked as passed")
@@ -88,13 +96,13 @@ class StopEtaTest {
     fun `an upcoming stop the feed hasn't timed yet is left plain`() {
         // NTA's predictions are sparse; a stop that is ahead but untimed gets no marker treatment,
         // rather than being wrongly greyed out as passed.
-        val etas = stopEtasFor(busAt("C" to null, "D" to inMinutes(12)), stops, nowMs = nowMs)
+        val etas = stopEtasFor(busAt("C" to null, "D" to inMinutes(12)), stops, zone = zone)
         assertNull(etas["C"], "An ahead-but-untimed stop should not be labelled or muted")
         assertTrue(etas.getValue("D").upcoming)
     }
 
     @Test
     fun `with no bus in the feed nothing is annotated`() {
-        assertTrue(stopEtasFor(null, stops, nowMs = nowMs).isEmpty())
+        assertTrue(stopEtasFor(null, stops, zone = zone).isEmpty())
     }
 }


### PR DESCRIPTION
The per-stop labels on the route/tracking map became a countdown ("4′") in `e48d563` *"Make the tracking map readable on iOS"* (PR #96), which first shipped in **1.1.114**. This restores the clock time ("18:09") and brings the timeline gutter with it.

## Why it changed, and why that was too broad

That commit bundled two fixes. On iOS the times hung off the *right* of the marker, got clipped at the screen edge, and collided with Apple’s own place names. **Moving them under the marker is what fixed that** — making them relative was a separate call, and it went into shared code, so Android, desktop and web lost clock times to solve a problem they did not have.

The other stated reason was consistency: the timeline gutter counted minutes, so map and timeline disagreed about the same stop ("2′" next to "22:27"). That objection is real, so this fixes it the other way — **one formatter now serves both**, which is stronger than the previous arrangement where two call sites happened to agree.

## Changes

- `clockLabel` replaces `minutesLabel`; `stopEtasFor` and the `RouteTimeline` gutter both use it.
- The rendering `TimeZone` is injectable, so the formatted string can be asserted without depending on where the suite runs — CI is UTC, a dev Mac is not. This is what makes the output testable at all.
- `RouteTimeline` no longer needs `nowMs`; `stopEtasFor` no longer needs it either, since a clock label does not change as the clock ticks (also drops a per-minute `remember` invalidation on both maps).
- `gutter_min` / `gutter_hours_min` removed from both locales, having lost their only caller.

## Test plan

- [x] `./gradlew :shared:jvmTest` — 48 tests, 0 failures (one new: the label rolls over the hour, so 17:00 + 65 min is 18:05 and not 17:65)
- [x] `StopEtaTest` rewritten against clock output with a pinned UTC zone
- [x] Compiles on Android, desktop/JVM, wasmJs, iOS arm64 + simulator, and `:mcp-server`
- [x] **Verified on an emulator against a bus with live predictions** (vehicle #1974): map reads `18:09` beside Spanish Arch and `18:33` beside Fr Griffin Rd, and the timeline gutter reads `18:05 / 18:09 / 18:33` for the same stops — the map and timeline now agree exactly, which was the point
- [ ] iOS unverified as usual — no XCUITest for these screens

## Two things to note

- The info card is unchanged and still shows a countdown ("Arriving at Spanish Arch — **3 min**"). That reads well next to clock-timed stops — countdown for the one you are waiting on, times for the rest — but say the word if you want it switched too.
- Clock labels are wider than "4′", so they crowd the markers a little more; in testing one label sat partly behind a bus marker. The three-label cap still applies. If it proves noisy, the lever is `labelledAhead` in `stopEtasFor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uucVCGLGoR4gpqkxNMzT