### PR TITLE
Fix Android startup crash by syncing material3 version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,8 @@ kotlinx-io = "0.9.1"
 kotlinx-serialization = "1.11.0"
 ktor = "3.5.2"
 maps-compose = "8.6.0"
-material3 = "1.11.0-alpha07"
+# must stay in sync with the composeMultiplatform version above (material3 is released on its own track)
+material3 = "1.12.0-alpha03"
 mcp = "0.15.0"
 shadowPlugin = "9.6.1"
 


### PR DESCRIPTION
The Android app crashed on startup with:

```
java.lang.AbstractMethodError: abstract method "void androidx.compose.foundation.style.CustomStyle.applyStyle(...)"
```

**Root cause:** dependency version skew. Compose Multiplatform (runtime/foundation/ui) was `1.12.0` while `org.jetbrains.compose.material3:material3` was pinned at `1.11.0-alpha07`, compiled against an incompatible `foundation` styling API.

**Fix:** bump `material3` to `1.12.0-alpha03` (newest build on the 1.12 line; material3 for CMP is released on its own version track) and add a comment noting it must stay in sync with `composeMultiplatform`.

**Verification:** reproduced the crash before the change, then `./gradlew :androidApp:assembleDebug` succeeded and the app installed and launched on an emulator with no crash in logcat.